### PR TITLE
Reduce PMTiles size by filtering to essential fields

### DIFF
--- a/gelos/pmtiles_generation.py
+++ b/gelos/pmtiles_generation.py
@@ -74,7 +74,7 @@ tippecanoe -zg \
 subprocess.run(cmd, shell=True, check=True)
 
 cmd = f"""
-tippecanoe -f -zg \
+tippecanoe -f \
   -ps \
   --no-tiny-polygon-reduction \
   --no-tile-size-limit \


### PR DESCRIPTION
Optimized PMTiles generation by including only the necessary fields (`category`, `id`, `color`, and `geometry`) for Mapbox GL PMTiles rendering in the gelos app.