### PR TITLE
remove jsonargparse from instantiation pipeline, fixes #42

### DIFF
--- a/gelos/analysis.py
+++ b/gelos/analysis.py
@@ -250,6 +250,9 @@ def run_analysis(
                     layer_dir.mkdir(exist_ok=True, parents=True)
                     _save_transform_result(result, chip_indices, cache_path, t_type, prefix)
 
+            # --- Resolve labels (used by metrics and models) ---
+            labels = ctx.chip_gdf[ctx.category_column].loc[chip_indices].to_numpy()
+
             # --- Run metrics ---
             for met_cfg in strategy_cfg.get("metrics", []):
                 met_type = met_cfg["type"]
@@ -262,11 +265,13 @@ def run_analysis(
                     )
 
                 cache_path = layer_dir / f"{prefix}_{met_type}.csv"
-                # if cache_path.exists():
-                #     logger.info(f"cached {met_type} result exists at {cache_path}, skipping")
-                # else:
-                met_fn = METRICS[met_type]
-                met_fn(embeddings, output_dir=layer_dir, prefix=prefix, **met_params)
+                if cache_path.exists():
+                    logger.info(f"cached {met_type} result exists at {cache_path}, skipping")
+                else:
+                    met_fn = METRICS[met_type]
+                    met_fn(
+                        embeddings, output_dir=layer_dir, prefix=prefix, labels=labels, **met_params
+                    )
 
             # --- Run plots ---
             for p_cfg in strategy_cfg.get("plots", []):
@@ -327,7 +332,6 @@ def run_analysis(
                     continue
 
                 data = transform_results[source]
-                labels = ctx.chip_gdf[ctx.category_column].loc[chip_indices].to_numpy()
                 run_name = f"{prefix}_{m_type}"
                 logger.info(f"running model {m_type} for {strategy_key}")
                 m_fn = MODELS[m_type]

--- a/gelos/comp_metrics.py
+++ b/gelos/comp_metrics.py
@@ -9,12 +9,27 @@ from scipy.stats import wasserstein_distance as _wasserstein_1d
 from sklearn.decomposition import PCA
 from sklearn.metrics.pairwise import cosine_similarity
 
+from gelos.analysis import build_prefix
+
+
+def _resolve_metric_csv(exp, processed_data_dir: Path, metric_name: str) -> Path:
+    """Resolve the deterministic CSV path for a per-experiment metric."""
+    exp_prefix = build_prefix(exp.config, exp.strategy, exp.layer)
+    return (
+        processed_data_dir
+        / exp.data_version
+        / exp.config
+        / exp.layer
+        / f"{exp_prefix}_{metric_name}.csv"
+    )
+
 
 def pca_ablation_comparison(
-    experiment_embeddings: list[tuple[str, np.ndarray]],
+    experiment_embeddings: list[tuple[str, np.ndarray | None]],
     processed_data_dir: Path,
     output_dir: Path,
     prefix: str,
+    experiments: list | None = None,
     **kwargs,
 ) -> dict:
     """Join per-experiment PCA ablation CSVs into a single comparison table.
@@ -27,20 +42,22 @@ def pca_ablation_comparison(
         processed_data_dir: Root processed directory to resolve per-experiment CSVs.
         output_dir: Directory to write the comparison CSV.
         prefix: File name prefix for the comparison output.
+        experiments: List of :class:`ComparisonExperiment` objects for path resolution.
 
     Returns:
         Dict with ``comparison_df`` key holding the merged DataFrame.
     """
+    if experiments is None:
+        raise ValueError("pca_ablation_comparison requires 'experiments' to resolve CSV paths")
+
     frames = []
-    for label, _ in experiment_embeddings:
-        # Search for pca_ablation CSV matching this label
-        csvs = list(processed_data_dir.rglob("*_pca_ablation.csv"))
-        if not csvs:
-            logger.warning(f"no pca_ablation CSV found for '{label}', skipping")
+    for exp in experiments:
+        csv_path = _resolve_metric_csv(exp, processed_data_dir, "pca_ablation")
+        if not csv_path.exists():
+            logger.warning(f"no pca_ablation CSV found for '{exp.label}' at {csv_path}, skipping")
             continue
-        # Use first match — in practice each experiment produces one
-        df = pd.read_csv(csvs[0])
-        df["experiment"] = label
+        df = pd.read_csv(csv_path)
+        df["experiment"] = exp.label
         frames.append(df)
 
     if not frames:
@@ -134,8 +151,61 @@ def wasserstein_distance(
     return {"labels": labels, "matrix": dist_matrix, "df": df}
 
 
+def knn_purity_comparison(
+    experiment_embeddings: list[tuple[str, np.ndarray | None]],
+    processed_data_dir: Path,
+    output_dir: Path,
+    prefix: str,
+    experiments: list | None = None,
+    **kwargs,
+) -> dict:
+    """Join per-experiment KNN purity CSVs into a single comparison table.
+
+    Each experiment's ``{prefix}_knn_purity.csv`` must already exist
+    (produced by the analysis-stage ``knn_purity`` metric).
+
+    Args:
+        experiment_embeddings: List of (label, embeddings) tuples (embeddings unused here).
+        processed_data_dir: Root processed directory to resolve per-experiment CSVs.
+        output_dir: Directory to write the comparison CSV.
+        prefix: File name prefix for the comparison output.
+        experiments: List of :class:`ComparisonExperiment` objects for path resolution.
+
+    Returns:
+        Dict with ``comparison_df`` key holding the merged DataFrame.
+    """
+    if experiments is None:
+        raise ValueError("knn_purity_comparison requires 'experiments' to resolve CSV paths")
+
+    frames = []
+    for exp in experiments:
+        csv_path = _resolve_metric_csv(exp, processed_data_dir, "knn_purity")
+        if not csv_path.exists():
+            logger.warning(f"no knn_purity CSV found for '{exp.label}' at {csv_path}, skipping")
+            continue
+        df = pd.read_csv(csv_path)
+        df["experiment"] = exp.label
+        frames.append(df)
+
+    if not frames:
+        logger.warning("no KNN purity data found for any experiment")
+        return {"comparison_df": pd.DataFrame()}
+
+    merged = pd.concat(frames, ignore_index=True)
+    csv_path = output_dir / f"{prefix}_knn_purity_comparison.csv"
+    merged.to_csv(csv_path, index=False)
+    logger.info(f"saved KNN purity comparison to {csv_path}")
+    return {"comparison_df": merged}
+
+
+pca_ablation_comparison.requires_embeddings = False
+cosine_distance.requires_embeddings = True
+wasserstein_distance.requires_embeddings = True
+knn_purity_comparison.requires_embeddings = False
+
 COMP_METRICS: dict[str, callable] = {
     "pca_ablation_comparison": pca_ablation_comparison,
     "cosine_distance": cosine_distance,
     "wasserstein_distance": wasserstein_distance,
+    "knn_purity_comparison": knn_purity_comparison,
 }

--- a/gelos/comp_plots.py
+++ b/gelos/comp_plots.py
@@ -62,8 +62,12 @@ def pca_ablation_table(
             n = n_comp_pivot.values[i, j]
             if not np.isnan(pct):
                 ax.text(
-                    j, i, f"{int(pct*100)}%\n({int(n)})",
-                    ha="center", va="center", fontsize=9,
+                    j,
+                    i,
+                    f"{int(pct * 100)}%\n({int(n)})",
+                    ha="center",
+                    va="center",
+                    fontsize=9,
                 )
 
     fig.colorbar(im, ax=ax, label="Percentage of Components")
@@ -115,7 +119,89 @@ def distance_matrix(
     plt.close(fig)
 
 
+def knn_purity_plot(
+    metric_result: dict,
+    output_path: str | Path = None,
+    **kwargs,
+) -> None:
+    """Render KNN class purity comparison as line plots.
+
+    Creates a figure with two subplots:
+    - Top: overall purity vs k, one line per experiment
+    - Bottom: per-class purity vs k, faceted by experiment
+
+    Args:
+        metric_result: Output from ``knn_purity_comparison`` metric.
+        output_path: Path to save the figure. Shows interactively if None.
+    """
+    df = metric_result.get("comparison_df", pd.DataFrame())
+    if df.empty:
+        logger.warning("no data for KNN purity plot, skipping")
+        return
+
+    overall = df[df["class"] == "overall"]
+    per_class = df[df["class"] != "overall"]
+    experiments = overall["experiment"].unique()
+
+    fig, (ax_top, ax_bot) = plt.subplots(2, 1, figsize=(10, 8))
+
+    # --- Top: overall purity ---
+    markers = ["o", "s", "^", "D", "v", "P", "X", "*"]
+    for i, exp in enumerate(experiments):
+        exp_data = overall[overall["experiment"] == exp].sort_values("k")
+        marker = markers[i % len(markers)]
+        ax_top.plot(exp_data["k"], exp_data["purity"], marker=marker, label=exp)
+
+    ax_top.set_xlabel("k")
+    ax_top.set_ylabel("Purity")
+    ax_top.set_ylim(0, 1.05)
+    ax_top.set_title("Overall KNN Class Purity by Experiment")
+    ax_top.legend()
+    ax_top.grid(True, alpha=0.3)
+
+    # --- Bottom: per-class purity ---
+    classes = sorted(per_class["class"].unique())
+    n_classes = len(classes)
+    n_experiments = len(experiments)
+    k_values = sorted(per_class["k"].unique())
+    x = np.arange(len(k_values))
+    total_bars = n_classes * n_experiments
+    width = 0.8 / max(total_bars, 1)
+
+    for i, exp in enumerate(experiments):
+        for j, cls in enumerate(classes):
+            subset = per_class[
+                (per_class["experiment"] == exp) & (per_class["class"] == cls)
+            ].sort_values("k")
+            offset = (i * n_classes + j - total_bars / 2) * width + width / 2
+            bar_vals = [
+                subset[subset["k"] == k]["purity"].values[0]
+                if len(subset[subset["k"] == k]) > 0
+                else 0
+                for k in k_values
+            ]
+            ax_bot.bar(x + offset, bar_vals, width, label=f"{exp} — {cls}")
+
+    ax_bot.set_xlabel("k")
+    ax_bot.set_ylabel("Purity")
+    ax_bot.set_ylim(0, 1.05)
+    ax_bot.set_xticks(x)
+    ax_bot.set_xticklabels([str(k) for k in k_values])
+    ax_bot.set_title("Per-Class KNN Purity by Experiment")
+    ax_bot.legend(fontsize=7, ncol=2)
+    ax_bot.grid(True, alpha=0.3, axis="y")
+
+    fig.tight_layout()
+
+    if output_path:
+        plt.savefig(output_path, dpi=300, bbox_inches="tight")
+    else:
+        plt.show()
+    plt.close(fig)
+
+
 COMP_PLOTS: dict[str, callable] = {
     "pca_ablation_table": pca_ablation_table,
     "distance_matrix": distance_matrix,
+    "knn_purity_plot": knn_purity_plot,
 }

--- a/gelos/comparison.py
+++ b/gelos/comparison.py
@@ -121,31 +121,46 @@ def run_comparison(
     """
     ctx = setup_comparison(yaml_path, processed_data_dir, figures_base_dir)
 
-    # Load embeddings for each experiment
-    loaded: list[tuple[str, np.ndarray]] = []
-    for exp in ctx.experiments:
-        emb_path = _resolve_embedding_path(exp, processed_data_dir)
-        if not emb_path.exists():
-            logger.warning(f"embeddings not found for '{exp.label}' at {emb_path}, skipping")
-            continue
-        emb = np.load(emb_path)
-        loaded.append((exp.label, emb))
-        logger.info(f"loaded embeddings for '{exp.label}': shape={emb.shape}")
+    # Determine whether any metric requires loading embeddings
+    any_needs_embeddings = any(
+        getattr(COMP_METRICS.get(m["type"]), "requires_embeddings", True)
+        for m in ctx.comp_metrics
+    )
 
-    if len(loaded) < 2:
-        logger.warning(
-            f"need at least 2 experiments with embeddings for comparison, got {len(loaded)}"
-        )
-        return {}
+    # Build experiment lists: always build labels-only, load arrays only when needed
+    labels_only: list[tuple[str, None]] = [(exp.label, None) for exp in ctx.experiments]
+    loaded: list[tuple[str, np.ndarray]] | None = None
 
-    # Validate embedding dimensionality
-    dim = loaded[0][1].shape[1]
-    for label, emb in loaded[1:]:
-        if emb.shape[1] != dim:
-            raise ValueError(
-                f"embedding dimension mismatch: '{loaded[0][0]}' has {dim} dims, "
-                f"'{label}' has {emb.shape[1]} dims"
+    if any_needs_embeddings:
+        loaded = []
+        for exp in ctx.experiments:
+            emb_path = _resolve_embedding_path(exp, processed_data_dir)
+            if not emb_path.exists():
+                logger.warning(
+                    f"embeddings not found for '{exp.label}' at {emb_path}, skipping"
+                )
+                continue
+            emb = np.load(emb_path)
+            loaded.append((exp.label, emb))
+            logger.info(f"loaded embeddings for '{exp.label}': shape={emb.shape}")
+
+        if len(loaded) < 2:
+            logger.warning(
+                f"need at least 2 experiments with embeddings for comparison, "
+                f"got {len(loaded)}"
             )
+            return {}
+
+        # Validate embedding dimensionality
+        dim = loaded[0][1].shape[1]
+        for label, emb in loaded[1:]:
+            if emb.shape[1] != dim:
+                raise ValueError(
+                    f"embedding dimension mismatch: '{loaded[0][0]}' has {dim} dims, "
+                    f"'{label}' has {emb.shape[1]} dims"
+                )
+    else:
+        logger.info("no metrics require embeddings, skipping embedding loading")
 
     # Dispatch metrics
     metric_results: dict[str, dict] = {}
@@ -160,11 +175,15 @@ def run_comparison(
             )
 
         met_fn = COMP_METRICS[met_type]
+        needs_emb = getattr(met_fn, "requires_embeddings", True)
+        experiment_data = loaded if needs_emb else labels_only
+
         result = met_fn(
-            loaded,
+            experiment_data,
             processed_data_dir=processed_data_dir,
             output_dir=ctx.output_dir,
             prefix=ctx.config_stem,
+            experiments=ctx.experiments,
             **met_params,
         )
         metric_results[met_type] = result

--- a/gelos/gelosdatamodule.py
+++ b/gelos/gelosdatamodule.py
@@ -1,3 +1,4 @@
+import importlib
 from pathlib import Path
 from typing import Any, List
 
@@ -23,7 +24,7 @@ class GELOSDataModule(NonGeoDataModule):
         data_root: str | Path,
         batch_size: int,
         num_workers: int,
-        dataset_class: type,
+        dataset_class: type | str,
         means: dict[str, dict[str, float]] | None = None,
         stds: dict[str, dict[str, float]] | None = None,
         bands: dict[str, List[str]] | None = None,
@@ -52,6 +53,10 @@ class GELOSDataModule(NonGeoDataModule):
             perturb_bands (dict[str, dict[str, float]], optional): perturb bands with additive gaussian noise. Dictionary defining modalities and bands with weights for perturbation.
             **kwargs: Additional keyword arguments.
         """
+        if isinstance(dataset_class, str):
+            module_path, _, class_name = dataset_class.rpartition(".")
+            dataset_class = getattr(importlib.import_module(module_path), class_name)
+
         super().__init__(dataset_class, batch_size, num_workers, **kwargs)
 
         self.data_root = data_root

--- a/gelos/generation.py
+++ b/gelos/generation.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from lightning.pytorch import Trainer
 from loguru import logger
@@ -7,7 +7,7 @@ from terratorch.tasks import EmbeddingGenerationTask
 import torch
 import typer
 import yaml
-from jsonargparse import ArgumentParser
+from lightning.pytorch.cli import instantiate_class
 from gelos.gelosdatamodule import GELOSDataModule
 
 app = typer.Typer()
@@ -16,6 +16,27 @@ app = typer.Typer()
 class LenientEmbeddingGenerationTask(EmbeddingGenerationTask):
     def check_file_ids(self, file_ids, x):
         return
+
+
+def instantiate_recursive(node: Any) -> Any:
+    """Walk a parsed YAML node and instantiate any ``{class_path, init_args}`` dicts bottom-up.
+
+    Bypasses jsonargparse introspection, which breaks on classes whose
+    ``__annotations__`` are rewritten by metaclasses (e.g. albumentations'
+    ``ValidatedTransformMeta``) and on group-name collisions with init params.
+    Any dict containing a ``class_path`` key is treated as an instantiation
+    spec; everything else is passed through untouched.
+    """
+    if isinstance(node, dict):
+        if "class_path" in node:
+            init_args = instantiate_recursive(node.get("init_args") or {})
+            return instantiate_class(
+                (), {"class_path": node["class_path"], "init_args": init_args}
+            )
+        return {k: instantiate_recursive(v) for k, v in node.items()}
+    if isinstance(node, list):
+        return [instantiate_recursive(item) for item in node]
+    return node
 
 
 def perturb_args_to_string(perturb):
@@ -67,22 +88,20 @@ def setup_embedding_run(
     output_dir.mkdir(exist_ok=True, parents=True)
     data_root = raw_data_dir / data_version
 
-    parser = ArgumentParser()
-    parser.add_class_arguments(GELOSDataModule, "data")
-    parser.add_class_arguments(LenientEmbeddingGenerationTask, "model")
+    yaml_config["data"]["init_args"]["data_root"] = str(data_root)
+    yaml_config["model"]["init_args"]["output_dir"] = str(output_dir)
 
-    data_init_args = yaml_config["data"]["init_args"]
-    data_init_args["data_root"] = str(data_root)
-    model_init_args = yaml_config["model"]["init_args"]
-    model_init_args["output_dir"] = str(output_dir)
+    datamodule: GELOSDataModule = instantiate_recursive(yaml_config["data"])
 
-    cfg = parser.parse_object({"data": data_init_args, "model": model_init_args})
-    init = parser.instantiate_classes(cfg)
+    # Override the task class with the lenient subclass but reuse the
+    # recursively-instantiated init_args from the YAML.
+    model_init_args = instantiate_recursive(yaml_config["model"].get("init_args") or {})
+    task = LenientEmbeddingGenerationTask(**model_init_args)
 
     device = "gpu" if torch.cuda.is_available() else "cpu"
     trainer = Trainer(accelerator=device, devices=1)
 
-    return init.data, init.model, trainer, output_dir
+    return datamodule, task, trainer, output_dir
 
 
 def generate_embeddings(

--- a/gelos/metrics.py
+++ b/gelos/metrics.py
@@ -6,6 +6,7 @@ from loguru import logger
 import numpy as np
 import pandas as pd
 from sklearn.decomposition import PCA
+from sklearn.neighbors import NearestNeighbors
 
 
 def pca_ablation(
@@ -61,6 +62,116 @@ def pca_ablation(
     return {"thresholds": rows}
 
 
+def knn_purity(
+    embeddings: np.ndarray,
+    output_dir: Path,
+    prefix: str,
+    labels: np.ndarray | None = None,
+    k_values: list[int] | None = None,
+    n_subsample: int | None = None,
+    random_state: int = 42,
+    **kwargs,
+) -> dict:
+    """Compute KNN class purity at multiple k values.
+
+    For each chip, measures what fraction of its k nearest neighbors share
+    the same class. Reports per-class and overall purity at each k.
+
+    Args:
+        embeddings: Input array of shape (N, D).
+        output_dir: Directory to write the result CSV.
+        prefix: File name prefix for the output CSV.
+        labels: Class labels of shape (N,). Required.
+        k_values: List of k values to evaluate.
+        n_subsample: If set, use a stratified subsample of query points.
+        random_state: Random state for reproducibility.
+
+    Returns:
+        Dict with ``rows`` list of per-k/per-class results and ``k_values``.
+    """
+    if labels is None:
+        raise ValueError("knn_purity requires labels")
+
+    if k_values is None:
+        k_values = [1, 2, 5, 10, 20, 50]
+
+    k_values = sorted(k_values)
+    max_k = max(k_values)
+    n_samples = embeddings.shape[0]
+
+    # Determine query indices (optionally subsample)
+    rng = np.random.RandomState(random_state)
+    if n_subsample is not None and n_subsample < n_samples:
+        # Stratified subsample
+        unique_classes = np.unique(labels)
+        query_indices = []
+        per_class_n = max(1, n_subsample // len(unique_classes))
+        for cls in unique_classes:
+            cls_indices = np.where(labels == cls)[0]
+            n_take = min(per_class_n, len(cls_indices))
+            query_indices.extend(rng.choice(cls_indices, size=n_take, replace=False))
+        query_indices = np.array(sorted(query_indices))
+    else:
+        query_indices = np.arange(n_samples)
+
+    # Fit on full embeddings, query with max_k+1 to exclude self
+    nn = NearestNeighbors(n_neighbors=min(max_k + 1, n_samples), algorithm="brute", n_jobs=-1)
+    nn.fit(embeddings)
+    _, neighbor_indices = nn.kneighbors(embeddings[query_indices])
+
+    # Exclude self (first column)
+    neighbor_indices = neighbor_indices[:, 1:]
+    query_labels = labels[query_indices]
+
+    rows = []
+    for k in k_values:
+        if k > neighbor_indices.shape[1]:
+            logger.warning(f"k={k} exceeds available neighbors, skipping")
+            continue
+
+        k_neighbors = neighbor_indices[:, :k]
+        k_neighbor_labels = labels[k_neighbors]
+        # Purity: fraction of neighbors sharing the query's class
+        matches = k_neighbor_labels == query_labels[:, np.newaxis]
+        per_query_purity = matches.mean(axis=1)
+
+        # Overall purity
+        overall = float(per_query_purity.mean())
+        rows.append(
+            {
+                "k": k,
+                "class": "overall",
+                "purity": overall,
+                "n_samples": len(query_indices),
+            }
+        )
+
+        # Per-class purity
+        unique_classes = np.unique(query_labels)
+        for cls in unique_classes:
+            mask = query_labels == cls
+            cls_purity = float(per_query_purity[mask].mean())
+            rows.append(
+                {
+                    "k": k,
+                    "class": str(cls),
+                    "purity": cls_purity,
+                    "n_samples": int(mask.sum()),
+                }
+            )
+
+        logger.info(f"KNN purity: k={k}, overall={overall:.4f}")
+
+    df = pd.DataFrame(rows)
+    csv_path = output_dir / f"{prefix}_knn_purity.csv"
+    output_dir.mkdir(exist_ok=True, parents=True)
+    df.to_csv(csv_path, index=False)
+    logger.info(f"saved KNN purity results to {csv_path}")
+
+    return {"rows": rows, "k_values": k_values}
+
+
 METRICS: dict[str, callable] = {
     "pca_ablation": pca_ablation,
+    "knn_purity": knn_purity,
 }

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 from shapely.geometry import Point
 
-from gelos.metrics import METRICS, pca_ablation
+from gelos.metrics import METRICS, knn_purity, pca_ablation
 from gelos.models import MODELS, run_knn_cv, run_linear_probe_cv, run_random_forest_cv
 from gelos.plotting import PLOTS
 from gelos.transforms import (
@@ -180,9 +180,11 @@ def test_random_forest_cv_returns_metrics(synthetic_embeddings, synthetic_labels
 
 
 def test_metrics_registry_keys():
-    """METRICS registry has pca_ablation entry."""
+    """METRICS registry has pca_ablation and knn_purity entries."""
     assert "pca_ablation" in METRICS
     assert callable(METRICS["pca_ablation"])
+    assert "knn_purity" in METRICS
+    assert callable(METRICS["knn_purity"])
 
 
 def test_pca_ablation_output(synthetic_embeddings, tmp_path):
@@ -205,7 +207,12 @@ def test_pca_ablation_output(synthetic_embeddings, tmp_path):
     import pandas as pd
 
     df = pd.read_csv(csv_files[0])
-    assert set(df.columns) == {"threshold", "n_components", "total_variance_explained"}
+    assert set(df.columns) == {
+        "threshold",
+        "n_components",
+        "proportion_of_total_components",
+        "total_variance_explained",
+    }
     assert len(df) == 5
     gc.collect()
 
@@ -226,6 +233,81 @@ def test_pca_ablation_cache_skip(synthetic_embeddings, tmp_path):
     # Run pca_ablation fresh to a different prefix to confirm it works
     pca_ablation(embeddings, output_dir=layer_dir, prefix="fresh")
     assert (layer_dir / "fresh_pca_ablation.csv").exists()
+    gc.collect()
+
+
+def test_knn_purity_output(synthetic_embeddings, synthetic_labels, tmp_path):
+    """knn_purity writes CSV with correct columns and sensible values."""
+    embeddings, _ = synthetic_embeddings
+    result = knn_purity(embeddings, output_dir=tmp_path, prefix="test", labels=synthetic_labels)
+
+    assert "rows" in result
+    assert "k_values" in result
+    assert len(result["rows"]) > 0
+
+    for row in result["rows"]:
+        assert 0.0 <= row["purity"] <= 1.0
+        assert row["n_samples"] > 0
+
+    csv_files = list(tmp_path.glob("*_knn_purity.csv"))
+    assert len(csv_files) == 1
+
+    import pandas as pd
+
+    df = pd.read_csv(csv_files[0])
+    assert set(df.columns) == {"k", "class", "purity", "n_samples"}
+    # Default 6 k values, each with overall + 3 classes = 4 rows per k = 24
+    assert len(df) == 6 * (1 + N_CLASSES)
+    gc.collect()
+
+
+def test_knn_purity_subsampling(synthetic_embeddings, synthetic_labels, tmp_path):
+    """knn_purity with n_subsample produces valid output with fewer queries."""
+    embeddings, _ = synthetic_embeddings
+    result = knn_purity(
+        embeddings,
+        output_dir=tmp_path,
+        prefix="test_sub",
+        labels=synthetic_labels,
+        n_subsample=30,
+    )
+
+    assert "rows" in result
+    for row in result["rows"]:
+        assert 0.0 <= row["purity"] <= 1.0
+        # Overall n_samples should be <= 30
+        if row["class"] == "overall":
+            assert row["n_samples"] <= 30
+
+    csv_files = list(tmp_path.glob("*_knn_purity.csv"))
+    assert len(csv_files) == 1
+    gc.collect()
+
+
+def test_knn_purity_perfect_clusters(tmp_path):
+    """Well-separated clusters should yield purity ~1.0 at small k."""
+    rng = np.random.RandomState(42)
+    n_per_class = 30
+    dim = 16
+
+    # Three tight clusters far apart
+    c0 = rng.randn(n_per_class, dim) * 0.01 + np.array([0] * dim)
+    c1 = rng.randn(n_per_class, dim) * 0.01 + np.array([100] * dim)
+    c2 = rng.randn(n_per_class, dim) * 0.01 + np.array([-100] * dim)
+    embeddings = np.vstack([c0, c1, c2]).astype(np.float32)
+    labels = np.array([0] * n_per_class + [1] * n_per_class + [2] * n_per_class)
+
+    result = knn_purity(
+        embeddings,
+        output_dir=tmp_path,
+        prefix="perfect",
+        labels=labels,
+        k_values=[1, 5, 10, 20],
+    )
+
+    for row in result["rows"]:
+        if row["class"] == "overall" and row["k"] <= 20:
+            assert row["purity"] > 0.95, f"Expected high purity at k={row['k']}"
     gc.collect()
 
 

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -7,11 +7,12 @@ import pytest
 from gelos.comp_metrics import (
     COMP_METRICS,
     cosine_distance,
+    knn_purity_comparison,
     pca_ablation_comparison,
     wasserstein_distance,
 )
-from gelos.comp_plots import COMP_PLOTS, distance_matrix, pca_ablation_table
-from gelos.comparison import setup_comparison
+from gelos.comp_plots import COMP_PLOTS, distance_matrix, knn_purity_plot, pca_ablation_table
+from gelos.comparison import ComparisonExperiment, setup_comparison
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -37,7 +38,12 @@ def two_experiment_embeddings():
 
 def test_comp_metrics_registry_keys():
     """COMP_METRICS registry has expected keys and callables."""
-    expected = {"pca_ablation_comparison", "cosine_distance", "wasserstein_distance"}
+    expected = {
+        "pca_ablation_comparison",
+        "cosine_distance",
+        "wasserstein_distance",
+        "knn_purity_comparison",
+    }
     assert expected <= set(COMP_METRICS.keys())
     for fn in COMP_METRICS.values():
         assert callable(fn)
@@ -45,7 +51,7 @@ def test_comp_metrics_registry_keys():
 
 def test_comp_plots_registry_keys():
     """COMP_PLOTS registry has expected keys and callables."""
-    expected = {"pca_ablation_table", "distance_matrix"}
+    expected = {"pca_ablation_table", "distance_matrix", "knn_purity_plot"}
     assert expected <= set(COMP_PLOTS.keys())
     for fn in COMP_PLOTS.values():
         assert callable(fn)
@@ -106,7 +112,7 @@ def test_wasserstein_distance(two_experiment_embeddings, tmp_path):
 
 def test_pca_ablation_comparison(tmp_path):
     """pca_ablation_comparison merges per-experiment CSVs into one."""
-    # Create fake per-experiment PCA ablation CSVs
+    # Create fake per-experiment PCA ablation CSVs at deterministic paths
     exp_dir = tmp_path / "v3" / "config_a" / "layer_11"
     exp_dir.mkdir(parents=True)
     df_a = pd.DataFrame(
@@ -118,18 +124,21 @@ def test_pca_ablation_comparison(tmp_path):
     )
     df_a.to_csv(exp_dir / "config_a_cls_layer_11_pca_ablation.csv", index=False)
 
-    # Provide dummy embeddings (not used by this metric)
-    dummy_emb = np.zeros((10, 8))
-    loaded = [("Exp A", dummy_emb)]
+    experiments = [
+        ComparisonExperiment(
+            data_version="v3", config="config_a", strategy="cls", layer="layer_11", label="Exp A"
+        ),
+    ]
 
     output_dir = tmp_path / "comparisons"
     output_dir.mkdir()
 
     result = pca_ablation_comparison(
-        loaded,
+        [(exp.label, None) for exp in experiments],
         processed_data_dir=tmp_path,
         output_dir=output_dir,
         prefix="test",
+        experiments=experiments,
     )
     assert "comparison_df" in result
     assert not result["comparison_df"].empty
@@ -161,11 +170,68 @@ def test_pca_ablation_table_plot(tmp_path):
             "experiment": ["A", "A", "B", "B"],
             "threshold": [0.9, 0.95, 0.9, 0.95],
             "n_components": [5, 10, 8, 15],
+            "proportion_of_total_components": [0.05, 0.10, 0.08, 0.15],
             "total_variance_explained": [0.91, 0.96, 0.92, 0.97],
         }
     )
     output_path = tmp_path / "test_pca_table.png"
     pca_ablation_table({"comparison_df": df}, output_path=output_path)
+    assert output_path.exists()
+    gc.collect()
+
+
+def test_knn_purity_comparison(tmp_path):
+    """knn_purity_comparison merges per-experiment CSVs into one."""
+    exp_dir = tmp_path / "v3" / "config_a" / "layer_11"
+    exp_dir.mkdir(parents=True)
+    df_a = pd.DataFrame(
+        {
+            "k": [1, 1, 5, 5],
+            "class": ["overall", "0", "overall", "0"],
+            "purity": [0.8, 0.9, 0.7, 0.75],
+            "n_samples": [100, 50, 100, 50],
+        }
+    )
+    df_a.to_csv(exp_dir / "config_a_cls_layer_11_knn_purity.csv", index=False)
+
+    experiments = [
+        ComparisonExperiment(
+            data_version="v3", config="config_a", strategy="cls", layer="layer_11", label="Exp A"
+        ),
+    ]
+
+    output_dir = tmp_path / "comparisons"
+    output_dir.mkdir()
+
+    result = knn_purity_comparison(
+        [(exp.label, None) for exp in experiments],
+        processed_data_dir=tmp_path,
+        output_dir=output_dir,
+        prefix="test",
+        experiments=experiments,
+    )
+    assert "comparison_df" in result
+    assert not result["comparison_df"].empty
+    assert "experiment" in result["comparison_df"].columns
+
+    csv_files = list(output_dir.glob("*_knn_purity_comparison.csv"))
+    assert len(csv_files) == 1
+    gc.collect()
+
+
+def test_knn_purity_plot_output(tmp_path):
+    """knn_purity_plot creates a PNG file from comparison data."""
+    df = pd.DataFrame(
+        {
+            "k": [1, 1, 1, 5, 5, 5, 1, 1, 1, 5, 5, 5],
+            "class": ["overall", "0", "1"] * 4,
+            "purity": [0.8, 0.9, 0.7, 0.75, 0.85, 0.65, 0.82, 0.88, 0.76, 0.78, 0.84, 0.72],
+            "n_samples": [100, 50, 50] * 4,
+            "experiment": ["A"] * 6 + ["B"] * 6,
+        }
+    )
+    output_path = tmp_path / "test_knn_purity.png"
+    knn_purity_plot({"comparison_df": df}, output_path=output_path)
     assert output_path.exists()
     gc.collect()
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -8,9 +8,8 @@ import numpy as np
 import pytest
 import rioxarray as rxr
 import torch
-from jsonargparse import ArgumentParser
-
 from gelos.gelosdatamodule import GELOSDataModule
+from gelos.generation import instantiate_recursive
 from gelos.gelosdataset import GELOSDataSet
 from tests.utils import create_test_geojson
 
@@ -372,8 +371,6 @@ def test_example_config_instantiates(data_root):
     class paths are importable, band names are valid, and the DataModule can
     set up and iterate.
     """
-    import importlib
-
     import yaml
 
     yaml_path = Path(__file__).parent / "fixtures" / "example_config.yaml"
@@ -381,15 +378,8 @@ def test_example_config_instantiates(data_root):
     with open(yaml_path, "r") as f:
         yaml_config = yaml.safe_load(f)
 
-    parser = ArgumentParser()
-    parser.add_class_arguments(GELOSDataModule, "data")
-
-    data_init_args = yaml_config['data']['init_args']
-    data_init_args['data_root'] = str(data_root)
-
-    cfg = parser.parse_object({"data": data_init_args})
-    init = parser.instantiate_classes(cfg)
-    gelos_datamodule = init.data
+    yaml_config["data"]["init_args"]["data_root"] = str(data_root)
+    gelos_datamodule = instantiate_recursive(yaml_config["data"])
 
     gelos_datamodule.setup(stage="predict")
     assert len(gelos_datamodule.dataset) == N_SAMPLES


### PR DESCRIPTION
This PR replaces all uses of jsonargparse from the instantiation pipeline to avoid version fragility due to jsonargparse not being able to read function signatures from albumentations. fixes #42