### PR TITLE
add raw pixel comparisons

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -187,3 +187,41 @@ For plots and models, the `transform` field selects which data to use as input: 
 ### Style
 
 Maps category values from your metadata to colors and labels for plotting. `category_column` must match a column accessible via `chip_gdf[category_column].loc[chip_indices]` in the analysis pipeline.
+
+## Raw-pixel baseline configs
+
+Randomly-initialized (or mis-pretrained) foundation-model weights can still produce embedding spaces that look reasonable on downstream probes. To sanity-check how much a model is actually contributing, GELOS ships `gelos.raw_pixels.RawPixelEmbeddingTask` — a passthrough task that skips the model entirely and writes the normalized raw pixels themselves as "embeddings". The output parquets match `EmbeddingGenerationTask`'s schema, so analysis and comparison stages consume them with no special-casing.
+
+Swap the `model` block for the raw task and add a top-level `raw_pixel_extraction` section:
+
+```yaml
+model:
+  class_path: gelos.raw_pixels.RawPixelEmbeddingTask
+  title: "Raw Pixel Baseline"
+  init_args:
+    patch_size: 16
+    embed_file_key: filename
+
+# Each named entry becomes a per-strategy subdir under the run's output_dir
+# (playing the role of a "layer" for analysis). The product of
+# len(timesteps) * len(patches) must be <= 4 — raw pixel tokens are high-dim,
+# so the cap keeps parquet sizes reasonable.
+raw_pixel_extraction:
+  center_2x2_t0:
+    title: "Center 2x2 patches, single timestep"
+    patches: center_2x2      # 'center_NxN' or an explicit list of [row, col] pairs
+    timesteps: [0]           # list of ints or the string 'all'
+  all_timesteps_center_patch:
+    title: "All timesteps of the center patch"
+    patches: center_1x1
+    timesteps: all
+```
+
+Notes:
+
+- **Normalization is reused from the datamodule.** The task trusts `GELOSDataModule.aug` (defaults to z-score via means/stds) — set real per-band statistics on your dataset class or in `data.init_args.means/stds`, or baseline pixels stay un-normalized.
+- **Patch grid is derived from `H, W, patch_size`**, not configured. All of `H`, `W` must be divisible by `patch_size`, and for multi-sensor configs all sensors must share `T`, `H`, `W` after normalization (use `repeat_bands` to align single-timestep modalities like DEM).
+- **Multi-modal runs channel-concatenate per token.** Do NOT set `concat_bands: True` on the datamodule — the task handles concat itself. Sensor order follows `data.bands` YAML key order, which becomes the dict iteration order. Reordering that block between runs produces parquets of the same shape but different channel layouts.
+- **Comparison workflow.** Each modality combination is its own generation config (`raw_s2.yaml`, `raw_s2s1dem.yaml`, etc.) with its own `data.bands` and its own `raw_pixel_extraction`. Comparison configs reference raw-pixel runs by the same `(config, strategy, layer)` triple as any model run. S2 pixels getting written twice is bounded (~kB/chip per run at the 4-token cap).
+
+`embedding_extraction_strategies` still applies on top — each raw-pixel subdir becomes a "layer" for analysis, and each embedding-extraction strategy runs its slice/transforms/plots/models against it.

--- a/gelos/analysis.py
+++ b/gelos/analysis.py
@@ -270,7 +270,11 @@ def run_analysis(
                 else:
                     met_fn = METRICS[met_type]
                     met_fn(
-                        embeddings, output_dir=layer_dir, prefix=prefix, labels=labels, **met_params
+                        embeddings,
+                        output_dir=layer_dir,
+                        prefix=prefix,
+                        labels=labels,
+                        **met_params,
                     )
 
             # --- Run plots ---

--- a/gelos/comp_plots.py
+++ b/gelos/comp_plots.py
@@ -125,12 +125,10 @@ def knn_purity_plot(
     class_labels: dict[str, str] | None = None,
     **kwargs,
 ) -> None:
-    """Render KNN class purity comparison as line plots.
+    """Render KNN class purity comparison as a per-class facet grid.
 
-    Creates a figure with:
-    - Top row (full width): overall purity vs k, one line per experiment.
-    - Facet grid below: one subplot per class, each showing purity vs k with
-      one line per experiment — makes cross-model comparison direct.
+    One subplot per class, each showing purity vs k with one line per
+    experiment — makes cross-model comparison direct.
 
     Args:
         metric_result: Output from ``knn_purity_comparison`` metric.
@@ -145,42 +143,22 @@ def knn_purity_plot(
 
     class_labels = class_labels or {}
 
-    overall = df[df["class"] == "overall"]
     per_class = df[df["class"] != "overall"]
-    experiments = list(overall["experiment"].unique())
+    experiments = list(per_class["experiment"].unique())
     classes = sorted(per_class["class"].unique())
     n_classes = len(classes)
 
     markers = ["o", "s", "^", "D", "v", "P", "X", "*"]
 
-    # Layout: 1 row for overall, then a facet grid (up to 4 cols) for classes.
-    n_cols = min(4, n_classes) if n_classes else 1
-    n_facet_rows = (n_classes + n_cols - 1) // n_cols if n_classes else 0
-    fig_height = 4 + 2.5 * n_facet_rows
+    n_cols = min(6, n_classes) if n_classes else 1
+    n_rows = (n_classes + n_cols - 1) // n_cols if n_classes else 1
+    fig_height = max(3, 2.5 * n_rows)
     fig = plt.figure(figsize=(3.5 * n_cols, fig_height))
-    gs = fig.add_gridspec(1 + n_facet_rows, n_cols, hspace=0.5, wspace=0.3)
+    gs = fig.add_gridspec(n_rows, n_cols, hspace=0.5, wspace=0.3)
 
-    # --- Top: overall purity (spans all columns) ---
-    ax_top = fig.add_subplot(gs[0, :])
-    for i, exp in enumerate(experiments):
-        exp_data = overall[overall["experiment"] == exp].sort_values("k")
-        ax_top.plot(
-            exp_data["k"],
-            exp_data["purity"],
-            marker=markers[i % len(markers)],
-            label=exp,
-        )
-    ax_top.set_xlabel("k")
-    ax_top.set_ylabel("Purity")
-    ax_top.set_ylim(0, 1.05)
-    ax_top.set_title("Overall KNN Class Purity by Experiment")
-    ax_top.legend()
-    ax_top.grid(True, alpha=0.3)
-
-    # --- Facets: one subplot per class ---
     facet_axes = []
     for idx, cls in enumerate(classes):
-        row = 1 + idx // n_cols
+        row = idx // n_cols
         col = idx % n_cols
         ax = fig.add_subplot(gs[row, col])
         facet_axes.append(ax)

--- a/gelos/gelosdatamodule.py
+++ b/gelos/gelosdatamodule.py
@@ -69,13 +69,13 @@ class GELOSDataModule(NonGeoDataModule):
         self.concat_bands = concat_bands
         self.repeat_bands = repeat_bands
         self.perturb_bands = perturb_bands
-        
+
         # handle passing stats with missing values, check against dataset class
         # if none are found, mean defaults to 0 and std defaults to 1
         means = means or {}
         stds = stds or {}
-        class_means = getattr(dataset_class, 'means', {})
-        class_stds = getattr(dataset_class, 'stds', {})
+        class_means = getattr(dataset_class, "means", {})
+        class_stds = getattr(dataset_class, "stds", {})
         self.means = {}
         self.stds = {}
         for modality in self.modalities:

--- a/gelos/gelosdataset.py
+++ b/gelos/gelosdataset.py
@@ -1,8 +1,9 @@
 from abc import abstractmethod
 from pathlib import Path
 from typing import Any
-from einops import rearrange
+
 import albumentations as A
+from einops import rearrange
 import numpy as np
 from terratorch.datasets.transforms import MultimodalTransforms
 import torch
@@ -15,6 +16,7 @@ class MultimodalToTensor:
     Stacking and unstacking in with terratorch.datasets.transforms ALSO rearranges from [T, H, W, C] to [C, T, H, W]
     Therefore, we must do the same here if we are not using them.
     """
+
     def __init__(self, modalities):
         self.modalities = modalities
 
@@ -22,7 +24,9 @@ class MultimodalToTensor:
         new_dict = {}
         for k, v in d.items():
             new_dict[k] = torch.from_numpy(v)
-            new_dict[k] = rearrange(new_dict[k], "time height width channels -> channels time height width")
+            new_dict[k] = rearrange(
+                new_dict[k], "time height width channels -> channels time height width"
+            )
         return new_dict
 
 
@@ -52,11 +56,11 @@ class GELOSDataSet(NonGeoDataset):
         perturb_bands: dict[str, dict[str, float]] | None = None,
     ) -> None:
 
-        self.bands=bands
-        self.all_band_names=all_band_names
-        self.concat_bands=concat_bands
-        self.repeat_bands=repeat_bands
-        self.perturb_bands=perturb_bands
+        self.bands = bands
+        self.all_band_names = all_band_names
+        self.concat_bands = concat_bands
+        self.repeat_bands = repeat_bands
+        self.perturb_bands = perturb_bands
 
         assert set(self.bands.keys()).issubset(set(self.all_band_names.keys())), (
             f"Please choose a subset of valid sensors: {self.all_band_names.keys()}"
@@ -142,10 +146,11 @@ class GELOSDataSet(NonGeoDataset):
 
     def _perturb_bands(self, output, sensor, band_dict):
         for band_index, alpha in band_dict.items():
-
             size = output[sensor][:, :, :, band_index].shape
             original_band = output[sensor][:, :, :, band_index]
-            noise = np.random.normal(loc=np.mean(original_band), scale=np.std(original_band), size=size)
+            noise = np.random.normal(
+                loc=np.mean(original_band), scale=np.std(original_band), size=size
+            )
             output[sensor][..., band_index] = (1 - alpha) * original_band + alpha * noise
 
         return output

--- a/gelos/generation.py
+++ b/gelos/generation.py
@@ -2,12 +2,13 @@ from pathlib import Path
 from typing import Any, Optional
 
 from lightning.pytorch import Trainer
+from lightning.pytorch.cli import instantiate_class
 from loguru import logger
 from terratorch.tasks import EmbeddingGenerationTask
 import torch
 import typer
 import yaml
-from lightning.pytorch.cli import instantiate_class
+
 from gelos.gelosdatamodule import GELOSDataModule
 
 app = typer.Typer()
@@ -62,7 +63,7 @@ def setup_embedding_run(
     yaml_path: Path,
     raw_data_dir: Path,
     embedding_dir: Path,
-) -> tuple[GELOSDataModule, LenientEmbeddingGenerationTask, Trainer, Path]:
+) -> tuple[GELOSDataModule, Any, Trainer, Path]:
     """Parse a YAML config and instantiate all objects needed for one embedding run.
 
     Useful in notebooks where you want to inspect or modify the datamodule, task,
@@ -89,14 +90,24 @@ def setup_embedding_run(
     data_root = raw_data_dir / data_version
 
     yaml_config["data"]["init_args"]["data_root"] = str(data_root)
+    yaml_config["model"].setdefault("init_args", {})
     yaml_config["model"]["init_args"]["output_dir"] = str(output_dir)
+
+    if "raw_pixel_extraction" in yaml_config:
+        yaml_config["model"]["init_args"]["extraction_strategies"] = yaml_config[
+            "raw_pixel_extraction"
+        ]
 
     datamodule: GELOSDataModule = instantiate_recursive(yaml_config["data"])
 
-    # Override the task class with the lenient subclass but reuse the
-    # recursively-instantiated init_args from the YAML.
-    model_init_args = instantiate_recursive(yaml_config["model"].get("init_args") or {})
-    task = LenientEmbeddingGenerationTask(**model_init_args)
+    model_class_path = yaml_config["model"].get("class_path", "")
+    if "EmbeddingGenerationTask" in model_class_path:
+        # Override the task class with the lenient subclass but reuse the
+        # recursively-instantiated init_args from the YAML.
+        model_init_args = instantiate_recursive(yaml_config["model"].get("init_args") or {})
+        task = LenientEmbeddingGenerationTask(**model_init_args)
+    else:
+        task = instantiate_recursive(yaml_config["model"])
 
     device = "gpu" if torch.cuda.is_available() else "cpu"
     trainer = Trainer(accelerator=device, devices=1)
@@ -110,7 +121,7 @@ def generate_embeddings(
     embedding_dir: Path,
     overwrite: bool = False,
 ) -> None:
-    
+
     datamodule, task, trainer, output_dir = setup_embedding_run(
         yaml_path, raw_data_dir, embedding_dir
     )
@@ -144,7 +155,9 @@ def main(
         "-c",
         help="Directory containing YAML configs (used when --yaml-path is not set).",
     ),
-    overwrite: Optional[bool] = typer.Option(False, "--overwrite", help="Overwrite existing embeddings"),
+    overwrite: Optional[bool] = typer.Option(
+        False, "--overwrite", help="Overwrite existing embeddings"
+    ),
 ):
     """
     Generate embeddings from a model and data specified in a yaml config.

--- a/gelos/models.py
+++ b/gelos/models.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from loguru import logger
 import numpy as np
 import pandas as pd
-from loguru import logger
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score

--- a/gelos/plotting.py
+++ b/gelos/plotting.py
@@ -65,9 +65,7 @@ def build_style_from_config(style_cfg: dict) -> tuple[str, dict, list[Patch]]:
     category_column = style_cfg["category_column"]
     color_dict = {str(k): v for k, v in style_cfg["colors"].items()}
     label_dict = {str(k): v for k, v in style_cfg["labels"].items()}
-    legend_patches = [
-        Patch(color=color, label=label_dict[k]) for k, color in color_dict.items()
-    ]
+    legend_patches = [Patch(color=color, label=label_dict[k]) for k, color in color_dict.items()]
     return category_column, color_dict, legend_patches
 
 
@@ -84,7 +82,7 @@ def temporal_cosine_similarity(
     n_timesteps: int = 4,
     timestep_labels: list[str] | None = None,
     n_cols: int = 6,
-    ylim: tuple[float, float] = (0.5,1)
+    ylim: tuple[float, float] = (0.5, 1),
 ) -> None:
     """Plot cosine similarity between consecutive timesteps per land-cover category.
 

--- a/gelos/raw_pixels.py
+++ b/gelos/raw_pixels.py
@@ -1,0 +1,202 @@
+from itertools import product
+from pathlib import Path
+from typing import Any
+
+from einops import rearrange
+import geopandas as gpd
+import numpy as np
+import torch
+from torch import nn
+from torchgeo.trainers import BaseTask
+
+
+class RawPixelEmbeddingTask(BaseTask):
+    """Passthrough Lightning task that writes raw normalized pixels as 'embeddings'.
+
+    Mirrors the output layout of ``terratorch.tasks.EmbeddingGenerationTask`` so
+    baseline runs flow through the existing analysis/comparison stages
+    unchanged. Normalization is expected to have already run inside
+    ``GELOSDataModule.on_after_batch_transfer`` via its ``aug`` pipeline.
+    """
+
+    def __init__(
+        self,
+        output_dir: str = "embeddings",
+        extraction_strategies: dict[str, dict[str, Any]] | None = None,
+        patch_size: int = 16,
+        embed_file_key: str = "filename",
+    ) -> None:
+        self.output_path = Path(output_dir)
+        self.output_path.mkdir(parents=True, exist_ok=True)
+        self.extraction_strategies = extraction_strategies or {}
+        self.patch_size = patch_size
+        self.embed_file_key = embed_file_key
+        super().__init__()
+
+    def configure_callbacks(self):
+        return []
+
+    def configure_models(self) -> None:
+        self.model = nn.Identity()
+
+    def _patch_grid(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Reshape ``[B, C, T, H, W]`` into a ``[B, T, nr, nc, C*ph*pw]`` patch grid."""
+        if tensor.ndim != 5:
+            raise ValueError(
+                f"expected 5D tensor [B, C, T, H, W], got {tensor.ndim}D shape {tuple(tensor.shape)}"
+            )
+        _, _, _, H, W = tensor.shape
+        if H % self.patch_size != 0 or W % self.patch_size != 0:
+            raise ValueError(
+                f"H ({H}) and W ({W}) must be divisible by patch_size ({self.patch_size})"
+            )
+        return rearrange(
+            tensor,
+            "b c t (nr ph) (nc pw) -> b t nr nc (c ph pw)",
+            ph=self.patch_size,
+            pw=self.patch_size,
+        )
+
+    def _resolve_patch_indices(
+        self, spec: dict, n_rows: int, n_cols: int
+    ) -> list[tuple[int, int]]:
+        patches = spec["patches"]
+        if isinstance(patches, str):
+            prefix = "center_"
+            if not patches.startswith(prefix) or "x" not in patches[len(prefix) :]:
+                raise ValueError(
+                    f"patches string '{patches}' must match 'center_NxN' (e.g. 'center_2x2')"
+                )
+            n_str, _, m_str = patches[len(prefix) :].partition("x")
+            if n_str != m_str:
+                raise ValueError(
+                    f"patches string '{patches}' must be square (N == M); got {n_str}x{m_str}"
+                )
+            try:
+                n = int(n_str)
+            except ValueError as exc:
+                raise ValueError(f"could not parse N from patches='{patches}'") from exc
+            if n > min(n_rows, n_cols):
+                raise ValueError(
+                    f"patches='{patches}' requires {n}x{n} but grid is {n_rows}x{n_cols}"
+                )
+            r0 = (n_rows - n) // 2
+            c0 = (n_cols - n) // 2
+            return [(r0 + dr, c0 + dc) for dr in range(n) for dc in range(n)]
+
+        resolved: list[tuple[int, int]] = []
+        for pair in patches:
+            if len(pair) != 2:
+                raise ValueError(f"patch pair {pair} must be [row, col]")
+            r, c = int(pair[0]), int(pair[1])
+            if not (0 <= r < n_rows and 0 <= c < n_cols):
+                raise ValueError(f"patch ({r}, {c}) out of range for grid {n_rows}x{n_cols}")
+            resolved.append((r, c))
+        return resolved
+
+    def _resolve_timestep_indices(self, spec: dict, T: int) -> list[int]:
+        timesteps = spec["timesteps"]
+        if isinstance(timesteps, str):
+            if timesteps != "all":
+                raise ValueError(f"timesteps string must be 'all', got '{timesteps}'")
+            return list(range(T))
+        resolved = [int(t) for t in timesteps]
+        for t in resolved:
+            if not (0 <= t < T):
+                raise ValueError(f"timestep {t} out of range [0, {T})")
+        return resolved
+
+    def _extract_raw_pixels(
+        self,
+        name: str,
+        image: torch.Tensor | dict[str, torch.Tensor],
+        spec: dict,
+    ) -> torch.Tensor:
+        if isinstance(image, dict):
+            if not image:
+                raise ValueError(f"strategy '{name}': empty image dict")
+            first_sensor = next(iter(image))
+            ref_shape = tuple(image[first_sensor].shape[-3:])
+            for sensor, t in image.items():
+                if tuple(t.shape[-3:]) != ref_shape:
+                    raise ValueError(
+                        f"strategy '{name}': sensor '{sensor}' has T,H,W={tuple(t.shape[-3:])} "
+                        f"but '{first_sensor}' has {ref_shape}"
+                    )
+            grids = [self._patch_grid(image[sensor]) for sensor in image.keys()]
+            grid = torch.cat(grids, dim=-1)
+        else:
+            grid = self._patch_grid(image)
+
+        _, T, n_rows, n_cols, _ = grid.shape
+        patch_indices = self._resolve_patch_indices(spec, n_rows, n_cols)
+        timestep_indices = self._resolve_timestep_indices(spec, T)
+
+        total = len(timestep_indices) * len(patch_indices)
+        if total > 4:
+            raise ValueError(f"strategy '{name}' resolves to {total} tokens, max is 4")
+
+        tokens = [
+            grid[:, t_idx, r, c, :] for t_idx, (r, c) in product(timestep_indices, patch_indices)
+        ]
+        return torch.stack(tokens, dim=1)
+
+    @torch.no_grad()
+    def predict_step(self, batch: dict, *args, **kwargs) -> None:
+        image = batch["image"]
+        filenames = batch[self.embed_file_key]
+        file_ids = batch.get("file_id")
+
+        for name, spec in self.extraction_strategies.items():
+            tokens = self._extract_raw_pixels(name, image, spec)
+            out_dir = self.output_path / name
+            out_dir.mkdir(parents=True, exist_ok=True)
+            B = tokens.shape[0]
+            for b in range(B):
+                filename = self._resolve_filename(filenames, b)
+                file_id = self._resolve_file_id(file_ids, b)
+                self.write_parquet(tokens[b], filename, file_id, out_dir)
+
+    @staticmethod
+    def _resolve_filename(filenames, b: int) -> str:
+        if isinstance(filenames, (list, tuple)):
+            return str(filenames[b])
+        if isinstance(filenames, np.ndarray):
+            return str(filenames[b])
+        if isinstance(filenames, torch.Tensor):
+            return str(filenames[b].item())
+        return str(filenames)
+
+    @staticmethod
+    def _resolve_file_id(file_ids, b: int):
+        if file_ids is None:
+            return None
+        if isinstance(file_ids, torch.Tensor):
+            return file_ids[b].item()
+        if isinstance(file_ids, np.ndarray):
+            value = file_ids[b]
+            return value.item() if value.ndim == 0 else value.tolist()
+        if isinstance(file_ids, (list, tuple)):
+            return file_ids[b]
+        return file_ids
+
+    def write_parquet(
+        self,
+        embedding: torch.Tensor,
+        filename: str,
+        file_id: Any,
+        dir_path: Path,
+    ) -> None:
+        filename = Path(filename).stem
+        out_path = dir_path / f"{filename}_embedding.parquet"
+        arr = embedding.detach().cpu().numpy()
+
+        row = {"embedding": arr.tolist()}
+        if file_id is not None:
+            row["file_id"] = file_id
+
+        df = gpd.GeoDataFrame([row])
+        df.to_parquet(out_path, index=False)
+
+
+__all__ = ["RawPixelEmbeddingTask"]

--- a/gelos/transforms.py
+++ b/gelos/transforms.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-import numpy as np
 from loguru import logger
+import numpy as np
 from sklearn.decomposition import PCA
 from sklearn.manifold import TSNE
 from umap import UMAP
+
 
 def tsne_from_embeddings(
     embeddings: np.ndarray,
@@ -30,8 +31,7 @@ def tsne_from_embeddings(
         Transformed array of shape (N, n_components).
     """
     logger.info(
-        f"running t-SNE: perplexity={perplexity}, n_components={n_components}, "
-        f"max_iter={max_iter}"
+        f"running t-SNE: perplexity={perplexity}, n_components={n_components}, max_iter={max_iter}"
     )
     tsne = TSNE(
         n_components=n_components,
@@ -41,6 +41,7 @@ def tsne_from_embeddings(
         verbose=verbose,
     )
     return tsne.fit_transform(embeddings)
+
 
 # TODO: continue updating to match UMAP params in scikitlearn
 def umap_from_embeddings(
@@ -68,9 +69,7 @@ def umap_from_embeddings(
     Returns:
         Transformed array of shape (N, n_components).
     """
-    logger.info(
-        f"running UMAP: n_neighbors={n_neighbors}, n_components={n_components}"
-    )
+    logger.info(f"running UMAP: n_neighbors={n_neighbors}, n_components={n_components}")
     umap_transformer = UMAP(
         n_components=n_components,
         n_neighbors=n_neighbors,
@@ -102,6 +101,7 @@ def pca_from_embeddings(
     logger.info(f"running PCA: n_components={n_components}")
     pca = PCA(n_components=n_components, random_state=random_state)
     return pca.fit_transform(embeddings)
+
 
 TRANSFORMS: dict[str, callable] = {
     "tsne": tsne_from_embeddings,

--- a/pixi.lock
+++ b/pixi.lock
@@ -611,6 +611,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - pypi: https://files.pythonhosted.org/packages/0e/c5/e3c81d05e4ab54fab5ba613c28ec91b2baee26671c5645293b1b020c13f4/pydeps-3.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/3d/2970b27a11ae17fb2d353e7a179763a2fe6f37d6d2a9f4d40104a2f132e9/stdlib_list-0.12.0-py3-none-any.whl
       - pypi: ./
   default:
     channels:
@@ -1207,6 +1209,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - pypi: https://files.pythonhosted.org/packages/0e/c5/e3c81d05e4ab54fab5ba613c28ec91b2baee26671c5645293b1b020c13f4/pydeps-3.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/3d/2970b27a11ae17fb2d353e7a179763a2fe6f37d6d2a9f4d40104a2f132e9/stdlib_list-0.12.0-py3-none-any.whl
       - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -3278,7 +3282,7 @@ packages:
 - pypi: ./
   name: gelos
   version: 0.2.0
-  sha256: d1bf118bb52509c6726ec537c9fdd10e41139244cfceabc3b62e700e85798451
+  sha256: bda9c7f35f08b2564f11c6fef087170b71125a63b05893c77f0e6b8e30b82d9d
   requires_python: ~=3.11.0
 - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.1.2-pyhd8ed1ab_0.conda
   sha256: 7c3e5dc62c0b3d067a6f517ea9176e9d52682499d4afb78704354a60f37c5444
@@ -8738,6 +8742,13 @@ packages:
   - pkg:pypi/pydantic-core?source=hash-mapping
   size: 1938184
   timestamp: 1762988992467
+- pypi: https://files.pythonhosted.org/packages/0e/c5/e3c81d05e4ab54fab5ba613c28ec91b2baee26671c5645293b1b020c13f4/pydeps-3.0.2-py3-none-any.whl
+  name: pydeps
+  version: 3.0.2
+  sha256: 890515899ffdb017255ba035704cfc711966469ad3aa3574c5b0b13f9f676e32
+  requires_dist:
+  - stdlib-list
+  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
   sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
   md5: 6b6ece66ebcae2d5f326c77ef2c5a066
@@ -10127,6 +10138,22 @@ packages:
   - pkg:pypi/stack-data?source=hash-mapping
   size: 26988
   timestamp: 1733569565672
+- pypi: https://files.pythonhosted.org/packages/3b/3d/2970b27a11ae17fb2d353e7a179763a2fe6f37d6d2a9f4d40104a2f132e9/stdlib_list-0.12.0-py3-none-any.whl
+  name: stdlib-list
+  version: 0.12.0
+  sha256: df2d11e97f53812a1756fb5510393a11e3b389ebd9239dc831c7f349957f62f2
+  requires_dist:
+  - build ; extra == 'dev'
+  - stdlib-list[test,lint,doc] ; extra == 'dev'
+  - sphinx ; extra == 'doc'
+  - furo ; extra == 'doc'
+  - mypy ; extra == 'lint'
+  - ruff ; extra == 'lint'
+  - sphobjinv ; extra == 'support'
+  - pytest ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - coverage[toml] ; extra == 'test'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.0-hecca717_0.conda
   sha256: e5e036728ef71606569232cc94a0480722e14ed69da3dd1e363f3d5191d83c01
   md5: 9a6117aee038999ffefe6082ff1e9a81

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
 ]
 requires-python = "~=3.11.0"
 
-
 [tool.ruff]
 line-length = 99
 src = ["gelos"]

--- a/tests/fixtures/example_raw_pixel_config.yaml
+++ b/tests/fixtures/example_raw_pixel_config.yaml
@@ -1,0 +1,91 @@
+experiment_name: "Raw Pixel Baseline - Multi-Sensor"
+data_version: "v0.50.1"
+chip_tracker: "gelos_chip_tracker.geojson"
+chip_id_column: "id"
+
+seed_everything: 0
+trainer:
+  accelerator: auto
+  strategy: auto
+  devices: auto
+  num_nodes: 1
+  callbacks: []
+  max_epochs: 0
+
+data:
+  class_path: gelos.gelosdatamodule.GELOSDataModule
+  init_args:
+    dataset_class: tests.test_data.ExampleGELOSDataSet
+    batch_size: 1
+    num_workers: 0
+    bands:
+      S2L2A:
+        - blue
+        - green
+        - red
+        - nir08
+        - swir16
+        - swir22
+      S1RTC:
+        - VV
+        - VH
+      DEM:
+        - DEM
+    repeat_bands:
+      DEM: 4
+    transform:
+      - class_path: terratorch.datasets.transforms.FlattenTemporalIntoChannels
+      - class_path: albumentations.augmentations.geometric.resize.Resize
+        init_args:
+          height: 96
+          width: 96
+          interpolation: 0
+      - class_path: albumentations.pytorch.transforms.ToTensorV2
+      - class_path: terratorch.datasets.transforms.UnflattenTemporalFromChannels
+        init_args:
+          n_timesteps: 4
+
+model:
+  class_path: gelos.raw_pixels.RawPixelEmbeddingTask
+  title: "Raw Pixel Baseline"
+  init_args:
+    patch_size: 16
+    embed_file_key: filename
+
+# Each named entry becomes a per-strategy subdir under output_dir.
+# The product of len(timesteps) * len(patches) must be <= 4.
+raw_pixel_extraction:
+  center_2x2_t0:
+    title: "Center 2x2 patches, single timestep"
+    patches: center_2x2
+    timesteps: [0]
+  all_timesteps_center_patch:
+    title: "All timesteps of the center patch"
+    patches: center_1x1
+    timesteps: all
+
+# Analysis picks up each raw_pixel_extraction subdir as a 'layer' and
+# applies each embedding_extraction_strategies entry to it.
+embedding_extraction_strategies:
+  all_tokens:
+    title: "All raw-pixel tokens"
+    slice_args:
+      - start: 0
+        stop: null
+        step: 1
+    transforms:
+      - type: pca
+        params:
+          n_components: 2
+    plots:
+      - type: scatter_2d
+        transform: pca
+
+style:
+  category_column: "lulc"
+  colors:
+    "1": "#419bdf"
+    "2": "#397d49"
+  labels:
+    "1": "Water"
+    "2": "Trees"

--- a/tests/test_raw_pixels.py
+++ b/tests/test_raw_pixels.py
@@ -1,0 +1,340 @@
+import gc
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from tests.test_data import ExampleGELOSDataSet  # noqa: F401 — resolve class_path in YAML
+from tests.utils import create_test_geojson
+import torch
+
+from gelos.analysis import run_analysis
+from gelos.generation import generate_embeddings
+from gelos.raw_pixels import RawPixelEmbeddingTask
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_task(tmp_path: Path, patch_size: int = 16, strategies=None) -> RawPixelEmbeddingTask:
+    return RawPixelEmbeddingTask(
+        output_dir=str(tmp_path),
+        extraction_strategies=strategies or {},
+        patch_size=patch_size,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Patch / timestep resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_center_2x2(tmp_path):
+    task = make_task(tmp_path)
+    spec = {"patches": "center_2x2", "timesteps": [0]}
+    indices = task._resolve_patch_indices(spec, n_rows=6, n_cols=6)
+    assert indices == [(2, 2), (2, 3), (3, 2), (3, 3)]
+
+
+def test_resolve_center_1x1_odd_grid(tmp_path):
+    task = make_task(tmp_path)
+    spec = {"patches": "center_1x1", "timesteps": [0]}
+    indices = task._resolve_patch_indices(spec, n_rows=7, n_cols=7)
+    assert indices == [(3, 3)]
+
+
+def test_resolve_center_1x1_even_grid(tmp_path):
+    task = make_task(tmp_path)
+    spec = {"patches": "center_1x1", "timesteps": [0]}
+    # top-left = ((6 - 1) // 2, (6 - 1) // 2) = (2, 2)
+    assert task._resolve_patch_indices(spec, n_rows=6, n_cols=6) == [(2, 2)]
+
+
+def test_resolve_explicit_list(tmp_path):
+    task = make_task(tmp_path)
+    spec = {"patches": [[0, 0], [2, 3]], "timesteps": [0]}
+    assert task._resolve_patch_indices(spec, n_rows=6, n_cols=6) == [(0, 0), (2, 3)]
+
+
+def test_resolve_patches_out_of_range_raises(tmp_path):
+    task = make_task(tmp_path)
+    spec = {"patches": [[10, 10]], "timesteps": [0]}
+    with pytest.raises(ValueError):
+        task._resolve_patch_indices(spec, n_rows=6, n_cols=6)
+
+
+def test_resolve_center_too_large_raises(tmp_path):
+    task = make_task(tmp_path)
+    spec = {"patches": "center_8x8", "timesteps": [0]}
+    with pytest.raises(ValueError):
+        task._resolve_patch_indices(spec, n_rows=6, n_cols=6)
+
+
+def test_resolve_timesteps_all(tmp_path):
+    task = make_task(tmp_path)
+    assert task._resolve_timestep_indices({"timesteps": "all"}, T=4) == [0, 1, 2, 3]
+
+
+def test_resolve_timesteps_explicit(tmp_path):
+    task = make_task(tmp_path)
+    assert task._resolve_timestep_indices({"timesteps": [0, 2]}, T=4) == [0, 2]
+
+
+def test_resolve_timesteps_out_of_range_raises(tmp_path):
+    task = make_task(tmp_path)
+    with pytest.raises(ValueError):
+        task._resolve_timestep_indices({"timesteps": [5]}, T=4)
+
+
+# ---------------------------------------------------------------------------
+# Extraction shapes
+# ---------------------------------------------------------------------------
+
+
+def test_extract_shape_tensor(tmp_path):
+    task = make_task(tmp_path, patch_size=16)
+    image = torch.zeros((2, 3, 4, 96, 96))
+    spec = {"patches": "center_2x2", "timesteps": [0]}
+    tokens = task._extract_raw_pixels("s", image, spec)
+    assert tuple(tokens.shape) == (2, 4, 3 * 16 * 16)
+
+
+def test_extract_shape_dict(tmp_path):
+    task = make_task(tmp_path, patch_size=16)
+    image = {
+        "S2L2A": torch.zeros((2, 6, 4, 96, 96)),
+        "S1RTC": torch.zeros((2, 2, 4, 96, 96)),
+        "DEM": torch.zeros((2, 1, 4, 96, 96)),
+    }
+    spec = {"patches": "center_2x2", "timesteps": [0]}
+    tokens = task._extract_raw_pixels("s", image, spec)
+    assert tuple(tokens.shape) == (2, 4, (6 + 2 + 1) * 16 * 16)
+
+
+# ---------------------------------------------------------------------------
+# Extraction values
+# ---------------------------------------------------------------------------
+
+
+def test_extract_values_tensor(tmp_path):
+    task = make_task(tmp_path, patch_size=2)
+    # [B=1, C=1, T=1, H=4, W=4] with sequential values
+    image = torch.arange(16, dtype=torch.float32).reshape(1, 1, 1, 4, 4)
+    spec = {"patches": [[0, 0]], "timesteps": [0]}
+    tokens = task._extract_raw_pixels("s", image, spec)
+    # top-left 2x2 patch flattens to [0, 1, 4, 5]
+    assert torch.equal(tokens[0, 0], torch.tensor([0.0, 1.0, 4.0, 5.0]))
+
+    spec = {"patches": [[1, 1]], "timesteps": [0]}
+    tokens = task._extract_raw_pixels("s", image, spec)
+    # bottom-right 2x2 patch flattens to [10, 11, 14, 15]
+    assert torch.equal(tokens[0, 0], torch.tensor([10.0, 11.0, 14.0, 15.0]))
+
+
+def test_extract_values_dict_channel_order(tmp_path):
+    task = make_task(tmp_path, patch_size=2)
+    image = {
+        "A": torch.full((1, 1, 1, 4, 4), 1.0),
+        "B": torch.full((1, 1, 1, 4, 4), 2.0),
+        "C": torch.full((1, 1, 1, 4, 4), 3.0),
+    }
+    spec = {"patches": [[0, 0]], "timesteps": [0]}
+    tokens = task._extract_raw_pixels("s", image, spec)
+    # flat_dim per sensor = 1*2*2 = 4 → sensor A occupies [0:4], B [4:8], C [8:12]
+    assert torch.equal(tokens[0, 0, 0:4], torch.full((4,), 1.0))
+    assert torch.equal(tokens[0, 0, 4:8], torch.full((4,), 2.0))
+    assert torch.equal(tokens[0, 0, 8:12], torch.full((4,), 3.0))
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_dict_sensor_shape_mismatch_raises(tmp_path):
+    task = make_task(tmp_path, patch_size=16)
+    image = {
+        "S2L2A": torch.zeros((1, 3, 4, 96, 96)),
+        "S1RTC": torch.zeros((1, 2, 2, 96, 96)),  # T mismatch
+    }
+    spec = {"patches": "center_1x1", "timesteps": [0]}
+    with pytest.raises(ValueError, match="S1RTC"):
+        task._extract_raw_pixels("mismatch", image, spec)
+
+
+def test_token_cap_exceeded_raises(tmp_path):
+    task = make_task(tmp_path, patch_size=16)
+    image = torch.zeros((1, 3, 3, 96, 96))
+    # 3 timesteps × 2 patches = 6 tokens > 4
+    spec = {"patches": [[0, 0], [0, 1]], "timesteps": "all"}
+    with pytest.raises(ValueError, match="strategy 'big' resolves to 6 tokens"):
+        task._extract_raw_pixels("big", image, spec)
+
+
+def test_h_not_divisible_raises(tmp_path):
+    task = make_task(tmp_path, patch_size=16)
+    image = torch.zeros((1, 3, 1, 90, 96))
+    with pytest.raises(ValueError):
+        task._patch_grid(image)
+
+
+def test_w_not_divisible_raises(tmp_path):
+    task = make_task(tmp_path, patch_size=16)
+    image = torch.zeros((1, 3, 1, 96, 90))
+    with pytest.raises(ValueError):
+        task._patch_grid(image)
+
+
+# ---------------------------------------------------------------------------
+# predict_step writes parquet
+# ---------------------------------------------------------------------------
+
+
+def test_predict_step_writes_parquet_tensor(tmp_path):
+    strategies = {
+        "center_1x1_t0": {"patches": "center_1x1", "timesteps": [0]},
+    }
+    task = make_task(tmp_path, patch_size=16, strategies=strategies)
+    batch = {
+        "image": torch.zeros((2, 3, 1, 96, 96)),
+        "filename": np.array(["000001", "000002"], dtype=str),
+        "file_id": torch.tensor([1, 2]),
+    }
+    task.predict_step(batch)
+
+    out_dir = tmp_path / "center_1x1_t0"
+    assert out_dir.exists()
+    parquet_files = sorted(out_dir.glob("*_embedding.parquet"))
+    assert len(parquet_files) == 2
+
+    df = pd.read_parquet(parquet_files[0])
+    assert "embedding" in df.columns
+    assert "file_id" in df.columns
+    emb = np.asarray(df["embedding"].iloc[0].tolist())
+    assert emb.shape == (1, 3 * 16 * 16)
+    gc.collect()
+
+
+def test_predict_step_writes_parquet_dict(tmp_path):
+    strategies = {
+        "center_2x2_t0": {"patches": "center_2x2", "timesteps": [0]},
+    }
+    task = make_task(tmp_path, patch_size=16, strategies=strategies)
+    batch = {
+        "image": {
+            "S2L2A": torch.zeros((1, 6, 1, 96, 96)),
+            "DEM": torch.zeros((1, 1, 1, 96, 96)),
+        },
+        "filename": np.array(["000001"], dtype=str),
+        "file_id": torch.tensor([1]),
+    }
+    task.predict_step(batch)
+
+    out_dir = tmp_path / "center_2x2_t0"
+    parquet_files = list(out_dir.glob("*_embedding.parquet"))
+    assert len(parquet_files) == 1
+    df = pd.read_parquet(parquet_files[0])
+    emb = np.asarray(df["embedding"].iloc[0].tolist())
+    assert emb.shape == (4, (6 + 1) * 16 * 16)
+    assert int(df["file_id"].iloc[0]) == 1
+    gc.collect()
+
+
+@pytest.fixture()
+def raw_pixel_run_dirs(tmp_path):
+    """Build raw_data_dir/<data_version>/ with dummy chips and return directory paths."""
+    data_version = "v0.50.1"
+    raw_data_dir = tmp_path / "raw"
+    embedding_dir = tmp_path / "interim"
+    processed_data_dir = tmp_path / "processed"
+    figures_dir = tmp_path / "figures"
+
+    versioned_data = raw_data_dir / data_version
+    versioned_data.mkdir(parents=True)
+
+    sensors = {
+        "S2L2A": len(ExampleGELOSDataSet.S2L2A_BAND_NAMES),
+        "S1RTC": len(ExampleGELOSDataSet.S1RTC_BAND_NAMES),
+        "DEM": len(ExampleGELOSDataSet.DEM_BAND_NAMES),
+    }
+    n_timesteps = {"S2L2A": 4, "S1RTC": 4, "DEM": 1}
+    create_test_geojson(versioned_data, n_samples=2, sensors=sensors, n_timesteps=n_timesteps, img_size=96)
+    # Tests rely on `lulc` labels for the analysis path; geojson here doesn't include them,
+    # but run_analysis only needs them if category-dependent steps run. Inject a simple lulc.
+    import geopandas as gpd
+
+    tracker = versioned_data / "gelos_chip_tracker.geojson"
+    gdf = gpd.read_file(tracker)
+    gdf["lulc"] = [1, 2]
+    gdf.to_file(tracker, driver="GeoJSON")
+
+    return {
+        "data_version": data_version,
+        "raw_data_dir": raw_data_dir,
+        "embedding_dir": embedding_dir,
+        "processed_data_dir": processed_data_dir,
+        "figures_dir": figures_dir,
+    }
+
+
+def test_raw_pixel_generation_e2e(raw_pixel_run_dirs):
+    yaml_path = Path(__file__).parent / "fixtures" / "example_raw_pixel_config.yaml"
+
+    generate_embeddings(
+        yaml_path,
+        raw_data_dir=raw_pixel_run_dirs["raw_data_dir"],
+        embedding_dir=raw_pixel_run_dirs["embedding_dir"],
+    )
+
+    config_stem = yaml_path.stem
+    data_version = raw_pixel_run_dirs["data_version"]
+    output_dir = raw_pixel_run_dirs["embedding_dir"] / data_version / config_stem
+
+    for strategy in ("center_2x2_t0", "all_timesteps_center_patch"):
+        strat_dir = output_dir / strategy
+        assert strat_dir.is_dir(), f"missing strategy dir {strat_dir}"
+        parquets = list(strat_dir.glob("*_embedding.parquet"))
+        assert len(parquets) == 2, f"expected 2 parquets in {strat_dir}, got {len(parquets)}"
+
+        df = pd.read_parquet(parquets[0])
+        assert "embedding" in df.columns
+        emb = np.asarray(df["embedding"].iloc[0].tolist())
+        assert emb.ndim == 2 and emb.shape[0] == 4  # 4 tokens each
+
+    assert (output_dir / ".embeddings_complete").exists()
+
+    run_analysis(
+        yaml_path,
+        raw_data_dir=raw_pixel_run_dirs["raw_data_dir"],
+        embedding_dir=raw_pixel_run_dirs["embedding_dir"],
+        processed_data_dir=raw_pixel_run_dirs["processed_data_dir"],
+        figures_base_dir=raw_pixel_run_dirs["figures_dir"],
+    )
+
+    processed_root = raw_pixel_run_dirs["processed_data_dir"] / data_version / config_stem
+    cached = list(processed_root.rglob("*_embeddings.npy"))
+    assert cached, f"expected cached _embeddings.npy under {processed_root}"
+
+
+def test_predict_step_multiple_strategies(tmp_path):
+    strategies = {
+        "center_1x1_t0": {"patches": "center_1x1", "timesteps": [0]},
+        "center_1x1_all": {"patches": "center_1x1", "timesteps": "all"},
+    }
+    task = make_task(tmp_path, patch_size=16, strategies=strategies)
+    batch = {
+        "image": torch.zeros((1, 3, 4, 96, 96)),
+        "filename": np.array(["000001"], dtype=str),
+        "file_id": torch.tensor([1]),
+    }
+    task.predict_step(batch)
+
+    assert (tmp_path / "center_1x1_t0" / "000001_embedding.parquet").exists()
+    assert (tmp_path / "center_1x1_all" / "000001_embedding.parquet").exists()
+
+    df = pd.read_parquet(tmp_path / "center_1x1_all" / "000001_embedding.parquet")
+    emb = np.asarray(df["embedding"].iloc[0].tolist())
+    # 4 timesteps × 1 patch = 4 tokens
+    assert emb.shape == (4, 3 * 16 * 16)
+    gc.collect()


### PR DESCRIPTION
This PR adds raw pixel comparisons to the pipeline. raw_pixels.py contains a RawPixelEmbeddingTask that mimics the generation pipeline so that raw pixels are extracted and can be run using the same analysis and comparison steps as the embeddings. This is intended to provide a baseline which measures the similarity/dissimilarity and usefulness in modeling of the pixel values themselved before being processed by GFMs.