### PR TITLE
Add violin plots as option for knn distribution comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ Downstream projects should pin to a release tag and update intentionally:
 gelos = {git = "https://github.com/ClarkCGA/gelos.git", tag = "v1.0.0"}
 ```
 
+## [Unreleased]
+
+- `knn_purity_violin_distribution_plot` comparison plot: a violin-plot alternative
+  to `knn_purity_distribution_plot` for the KNN per-query purity distribution.
+  Draws a *split* violin (one half per group) when exactly two experiments are
+  compared, and side-by-side single violins otherwise. The mode can be forced via
+  the `split` param. Means are marked with a diamond and medians with a short line,
+  matching the box-plot variant. Consumes the same
+  `knn_purity_per_query_comparison` metric output, so YAML configs must set
+  `metric: knn_purity_per_query_comparison` on the plot entry. A new `split_pairs`
+  param (list of 2-element experiment-name lists) renders each pair as a
+  side-by-side split violin per k, with any unpaired experiments drawn as single
+  violins; pairs naming a missing experiment are warned about and skipped.
+  `split_pairs` takes precedence over `split`.
+
 ## [v1.0.0] - 2026-03-23
 
 Initial public release.

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -188,6 +188,45 @@ For plots and models, the `transform` field selects which data to use as input: 
 
 Maps category values from your metadata to colors and labels for plotting. `category_column` must match a column accessible via `chip_gdf[category_column].loc[chip_indices]` in the analysis pipeline.
 
+### Comparison plots
+
+Comparison configs may list `comp_plots`, each with a `type` from the comparison
+plot registry and an optional `params` block. Each plot reads the output of a
+comparison metric; by default the source metric is derived from the plot `type`
+(stripping the `_plot`/`_table` suffix), but it can be set explicitly with a
+`metric` field — required when the names don't match.
+
+| Type | Description | Key params |
+|------|-------------|------------|
+| `knn_purity_distribution_plot` | Per-class box plots of per-query KNN purity vs k | (none) |
+| `knn_purity_violin_distribution_plot` | Per-class violin plots of per-query KNN purity vs k. Split violin (one half per group) when exactly two experiments are compared, otherwise side-by-side single violins. Mean shown as a diamond, median as a short line | `split` (bool, default auto: split iff exactly two experiments). `split_pairs` (list of 2-element experiment-name lists; each pair → one split violin per k; unpaired experiments → single violins; takes precedence over `split`). Requires `metric: knn_purity_per_query_comparison` |
+
+Example:
+
+```yaml
+comp_plots:
+  - type: knn_purity_violin_distribution_plot
+    metric: knn_purity_per_query_comparison
+    params:
+      split: true
+```
+
+To contrast several pairs of experiments as side-by-side split violins (for
+example multitemporal vs single-time-step variants of two models), use
+`split_pairs`. Each inner list names the two experiments of one split violin;
+any experiment not named in a valid pair is drawn as a single violin. When
+`split_pairs` is set it takes precedence over `split`:
+
+```yaml
+comp_plots:
+  - type: knn_purity_violin_distribution_plot
+    metric: knn_purity_per_query_comparison
+    params:
+      split_pairs:
+        - [model_A_multi, model_A_single]
+        - [model_B_multi, model_B_single]
+```
+
 ## Raw-pixel baseline configs
 
 Randomly-initialized (or mis-pretrained) foundation-model weights can still produce embedding spaces that look reasonable on downstream probes. To sanity-check how much a model is actually contributing, GELOS ships `gelos.raw_pixels.RawPixelEmbeddingTask` — a passthrough task that skips the model entirely and writes the normalized raw pixels themselves as "embeddings". The output parquets match `EmbeddingGenerationTask`'s schema, so analysis and comparison stages consume them with no special-casing.

--- a/gelos/comp_plots.py
+++ b/gelos/comp_plots.py
@@ -331,6 +331,282 @@ def knn_purity_distribution_plot(
     plt.close(fig)
 
 
+def knn_purity_violin_distribution_plot(
+    metric_result: dict,
+    output_path: str | Path = None,
+    class_labels: dict[str, str] | None = None,
+    experiment_colors: dict[str, str] | None = None,
+    *,
+    split: bool | None = None,
+    split_pairs: list[list[str]] | None = None,
+    **kwargs,
+) -> None:
+    """Render KNN per-query purity distribution as violin plots.
+
+    A violin alternative to :func:`knn_purity_distribution_plot`. Consumes the
+    identical metric output (``knn_purity_per_query_comparison``). One subplot
+    per class; the x-axis enumerates k values. When exactly two experiments are
+    compared the violins at each k are drawn as a *split* violin (experiment 0 =
+    left half, experiment 1 = right half) which is especially effective for
+    contrasting two groups (e.g. multitemporal vs single time step). Otherwise
+    (1 or 3+ experiments) side-by-side single violins are drawn. The mean is
+    marked with a diamond and the median with a short horizontal line, matching
+    the box-plot variant.
+
+    Args:
+        metric_result: Output from ``knn_purity_per_query_comparison`` metric.
+        output_path: Path to save the figure. Shows interactively if None.
+        class_labels: Optional mapping from class id (as string) to display
+            name. Used for facet subplot titles. Falls back to raw class id.
+        experiment_colors: Optional mapping from experiment label to color.
+        split: Force split (True) or side-by-side single (False) violins. When
+            None (default) split is used automatically iff there are exactly two
+            experiments. Ignored when ``split_pairs`` is provided.
+        split_pairs: Optional list of 2-element experiment-name lists. Each pair
+            is rendered as one split violin (``exp[0]`` = left half, ``exp[1]`` =
+            right half) per k tick, with the pairs laid out side-by-side. Any
+            experiment not named in a valid, retained pair is appended as a
+            single violin (in sorted ``experiments`` order). When provided,
+            ``split_pairs`` takes precedence over ``split`` (and the automatic
+            two-experiment split rule). A malformed pair (not exactly two names)
+            or a pair naming an experiment absent from the data logs a warning
+            and is skipped.
+    """
+    df = metric_result.get("comparison_df", pd.DataFrame())
+    if df.empty:
+        logger.warning("no data for KNN purity violin distribution plot, skipping")
+        return
+
+    class_labels = class_labels or {}
+
+    experiments = sorted(df["experiment"].unique())
+    classes = sorted(df["class"].unique())
+    k_values = sorted(df["k"].unique())
+    n_classes = len(classes)
+    n_experiments = len(experiments)
+    n_k = len(k_values)
+
+    color_map = _resolve_experiment_colors(experiments, experiment_colors)
+    colors = [color_map[exp] for exp in experiments]
+    violin_width = 0.8 / max(n_experiments, 1)
+
+    do_split = split if split is not None else (n_experiments == 2)
+
+    # Build a validated slot layout when split_pairs is provided. This takes
+    # precedence over `split`/`do_split` (see docstring).
+    slots: list[tuple] = []
+    slot_width = 0.8
+    if split_pairs is not None:
+        experiment_set = set(experiments)
+        valid_pairs: list[tuple[str, str]] = []
+        for pair in split_pairs:
+            if len(pair) != 2:
+                logger.warning(
+                    f"split_pairs entry {pair!r} is not a pair of two experiments, skipping"
+                )
+                continue
+            e0, e1 = pair
+            missing = [e for e in (e0, e1) if e not in experiment_set]
+            if missing:
+                logger.warning(
+                    f"split_pairs entry {pair!r} names experiment(s) {missing!r} "
+                    "not present in the data, skipping"
+                )
+                continue
+            valid_pairs.append((e0, e1))
+        paired = {e for pair in valid_pairs for e in pair}
+        unpaired = [e for e in experiments if e not in paired]
+        slots = [("pair", e0, e1) for (e0, e1) in valid_pairs]
+        slots += [("single", e) for e in unpaired]
+        n_slots = len(slots)
+        slot_width = 0.8 / max(n_slots, 1)
+
+    def _style_body(body, color):
+        body.set_facecolor(color)
+        body.set_edgecolor("black")
+        body.set_alpha(0.7)
+
+    def _mean_median(ax, x, values, color, half=None):
+        """Draw the mean diamond and a short median line for one violin/half."""
+        if half is None:
+            half = violin_width * 0.2
+        ax.plot(
+            x,
+            float(np.mean(values)),
+            marker="D",
+            markerfacecolor=color,
+            markeredgecolor="black",
+            markersize=4,
+            linestyle="none",
+            zorder=5,
+        )
+        med = float(np.median(values))
+        ax.hlines(med, x - half, x + half, color="black", linewidth=1)
+
+    n_cols = min(2, n_classes) if n_classes else 1
+    n_rows = (n_classes + n_cols - 1) // n_cols if n_classes else 1
+    fig_height = max(3.5, 3.5 * n_rows)
+    fig = plt.figure(figsize=(12, fig_height), constrained_layout=True)
+    gs = fig.add_gridspec(n_rows, n_cols)
+
+    for idx, cls in enumerate(classes):
+        ax = fig.add_subplot(gs[idx // n_cols, idx % n_cols])
+
+        if split_pairs is not None:
+            for k_idx, k in enumerate(k_values):
+                center = float(k_idx)
+                for s_idx, slot in enumerate(slots):
+                    slot_center = center + (s_idx - (n_slots - 1) / 2) * slot_width
+                    if slot[0] == "pair":
+                        _, e0, e1 = slot
+                        drew_center_line = False
+                        for half_idx, exp in enumerate((e0, e1)):
+                            values = df[
+                                (df["experiment"] == exp) & (df["class"] == cls) & (df["k"] == k)
+                            ]["purity"].to_numpy()
+                            if values.size == 0:
+                                continue
+                            left = half_idx == 0
+                            marker_x = slot_center + (
+                                -slot_width * 0.25 if left else slot_width * 0.25
+                            )
+                            if values.size >= 2 and np.ptp(values) > 0:
+                                parts = ax.violinplot(
+                                    [values],
+                                    positions=[slot_center],
+                                    # Clamp the split-body width to the slot so
+                                    # adjacent slots do not overlap.
+                                    widths=min(slot_width * 1.7, slot_width),
+                                    showextrema=False,
+                                    showmeans=False,
+                                    showmedians=False,
+                                )
+                                for body in parts["bodies"]:
+                                    verts = body.get_paths()[0].vertices
+                                    if left:
+                                        verts[:, 0] = np.minimum(verts[:, 0], slot_center)
+                                    else:
+                                        verts[:, 0] = np.maximum(verts[:, 0], slot_center)
+                                    _style_body(body, color_map[exp])
+                                if not drew_center_line:
+                                    ax.axvline(
+                                        slot_center,
+                                        color="black",
+                                        linewidth=0.6,
+                                        alpha=0.4,
+                                        zorder=1,
+                                    )
+                                    drew_center_line = True
+                            _mean_median(
+                                ax, marker_x, values, color_map[exp], half=slot_width * 0.2
+                            )
+                    else:
+                        _, exp = slot
+                        values = df[
+                            (df["experiment"] == exp) & (df["class"] == cls) & (df["k"] == k)
+                        ]["purity"].to_numpy()
+                        if values.size == 0:
+                            continue
+                        if values.size >= 2 and np.ptp(values) > 0:
+                            parts = ax.violinplot(
+                                [values],
+                                positions=[slot_center],
+                                widths=slot_width * 0.85,
+                                showextrema=False,
+                                showmeans=False,
+                                showmedians=False,
+                            )
+                            for body in parts["bodies"]:
+                                _style_body(body, color_map[exp])
+                        _mean_median(
+                            ax, slot_center, values, color_map[exp], half=slot_width * 0.2
+                        )
+        elif do_split and n_experiments == 2:
+            for k_idx, k in enumerate(k_values):
+                center = float(k_idx)
+                drew_center_line = False
+                for i, exp in enumerate(experiments):
+                    values = df[(df["experiment"] == exp) & (df["class"] == cls) & (df["k"] == k)][
+                        "purity"
+                    ].to_numpy()
+                    if values.size == 0:
+                        continue
+                    left = i == 0
+                    # Nudge the mean/median marker toward the populated half.
+                    marker_x = center + (-violin_width * 0.25 if left else violin_width * 0.25)
+                    if values.size >= 2 and np.ptp(values) > 0:
+                        parts = ax.violinplot(
+                            [values],
+                            positions=[center],
+                            widths=violin_width * 1.7,
+                            showextrema=False,
+                            showmeans=False,
+                            showmedians=False,
+                        )
+                        for body in parts["bodies"]:
+                            verts = body.get_paths()[0].vertices
+                            if left:
+                                verts[:, 0] = np.minimum(verts[:, 0], center)
+                            else:
+                                verts[:, 0] = np.maximum(verts[:, 0], center)
+                            _style_body(body, colors[i])
+                        if not drew_center_line:
+                            ax.axvline(center, color="black", linewidth=0.6, alpha=0.4, zorder=1)
+                            drew_center_line = True
+                    _mean_median(ax, marker_x, values, colors[i])
+        else:
+            for i, exp in enumerate(experiments):
+                offset = (i - (n_experiments - 1) / 2) * violin_width
+                for k_idx, k in enumerate(k_values):
+                    values = df[(df["experiment"] == exp) & (df["class"] == cls) & (df["k"] == k)][
+                        "purity"
+                    ].to_numpy()
+                    if values.size == 0:
+                        continue
+                    x = k_idx + offset
+                    if values.size >= 2 and np.ptp(values) > 0:
+                        parts = ax.violinplot(
+                            [values],
+                            positions=[x],
+                            widths=violin_width * 0.85,
+                            showextrema=False,
+                            showmeans=False,
+                            showmedians=False,
+                        )
+                        for body in parts["bodies"]:
+                            _style_body(body, colors[i])
+                    _mean_median(ax, x, values, colors[i])
+
+        display = class_labels.get(str(cls), str(cls))
+        ax.set_title(display)
+        ax.set_xlabel("k")
+        ax.set_ylabel("Purity")
+        ax.set_ylim(0, 1.05)
+        ax.set_xticks(range(n_k))
+        ax.set_xticklabels([str(k) for k in k_values])
+        ax.set_xlim(-0.5, n_k - 0.5)
+        ax.grid(True, alpha=0.3)
+
+    if n_experiments:
+        handles = [
+            Patch(facecolor=colors[i], edgecolor="black", label=experiments[i])
+            for i in range(n_experiments)
+        ]
+        fig.legend(
+            handles,
+            experiments,
+            loc="upper center",
+            ncol=min(n_experiments, 4),
+            bbox_to_anchor=(0.5, -0.02),
+        )
+
+    if output_path:
+        plt.savefig(output_path, dpi=300, bbox_inches="tight")
+    else:
+        plt.show()
+    plt.close(fig)
+
+
 def per_class_similarity_distribution_plot(
     metric_result: dict,
     output_path: str | Path = None,
@@ -499,5 +775,6 @@ COMP_PLOTS: dict[str, callable] = {
     "distance_matrix": distance_matrix,
     "knn_purity_plot": knn_purity_plot,
     "knn_purity_distribution_plot": knn_purity_distribution_plot,
+    "knn_purity_violin_distribution_plot": knn_purity_violin_distribution_plot,
     "per_class_similarity_distribution_plot": per_class_similarity_distribution_plot,
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "gelos"
-version = "0.3.5"
+version = "0.3.7"
 description = "Repository for Geospatial Exploration of Latent Observation Space (GELOS)"
 authors = [
   { name = "Denys Godwin" },

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -18,6 +18,7 @@ from gelos.comp_plots import (
     distance_matrix,
     knn_purity_distribution_plot,
     knn_purity_plot,
+    knn_purity_violin_distribution_plot,
     pca_ablation_table,
     per_class_similarity_distribution_plot,
 )
@@ -67,6 +68,7 @@ def test_comp_plots_registry_keys():
         "distance_matrix",
         "knn_purity_plot",
         "knn_purity_distribution_plot",
+        "knn_purity_violin_distribution_plot",
         "per_class_similarity_distribution_plot",
     }
     assert expected <= set(COMP_PLOTS.keys())
@@ -312,6 +314,175 @@ def test_knn_purity_distribution_plot_output(tmp_path):
     df = pd.DataFrame(rows)
     output_path = tmp_path / "test_knn_purity_distribution.png"
     knn_purity_distribution_plot({"comparison_df": df}, output_path=output_path)
+    assert output_path.exists()
+    gc.collect()
+
+
+def _make_per_query_df(experiments, classes=("0", "1"), ks=(1, 5), n_queries=20, seed=0):
+    """Build a synthetic per-query purity df for the violin plot tests."""
+    rng = np.random.RandomState(seed)
+    rows = []
+    for exp in experiments:
+        for cls in classes:
+            for k in ks:
+                for q_idx in range(n_queries):
+                    rows.append(
+                        {
+                            "experiment": exp,
+                            "class": cls,
+                            "k": k,
+                            "query_idx": q_idx,
+                            "purity": float(rng.rand()),
+                        }
+                    )
+    return pd.DataFrame(rows)
+
+
+def test_knn_purity_violin_distribution_plot_output(tmp_path):
+    """Two experiments -> split-violin path saves a PNG."""
+    df = _make_per_query_df(["A", "B"], seed=0)
+    output_path = tmp_path / "test_knn_purity_violin_distribution.png"
+    knn_purity_violin_distribution_plot({"comparison_df": df}, output_path=output_path)
+    assert output_path.exists()
+    gc.collect()
+
+
+def test_knn_purity_violin_distribution_plot_single_experiment(tmp_path):
+    """One experiment -> single-violin fallback saves a PNG."""
+    df = _make_per_query_df(["A"], seed=1)
+    output_path = tmp_path / "test_knn_purity_violin_single.png"
+    knn_purity_violin_distribution_plot({"comparison_df": df}, output_path=output_path)
+    assert output_path.exists()
+    gc.collect()
+
+
+def test_knn_purity_violin_distribution_plot_three_experiments(tmp_path):
+    """Three experiments -> side-by-side single-violin fallback saves a PNG."""
+    df = _make_per_query_df(["A", "B", "C"], seed=2)
+    output_path = tmp_path / "test_knn_purity_violin_three.png"
+    knn_purity_violin_distribution_plot({"comparison_df": df}, output_path=output_path)
+    assert output_path.exists()
+    gc.collect()
+
+
+def test_knn_purity_violin_distribution_plot_force_single_split(tmp_path):
+    """split=False forces single violins even with two experiments."""
+    df = _make_per_query_df(["A", "B"], seed=3)
+    output_path = tmp_path / "test_knn_purity_violin_force_single.png"
+    knn_purity_violin_distribution_plot(
+        {"comparison_df": df}, output_path=output_path, split=False
+    )
+    assert output_path.exists()
+    gc.collect()
+
+
+def test_knn_purity_violin_distribution_plot_degenerate(tmp_path):
+    """Constant/single-sample purity exercises the small-sample guard without raising."""
+    rows = []
+    # One experiment, constant purity (np.ptp == 0) and a single-sample group.
+    for cls, n in [("0", 5), ("1", 1)]:
+        for q_idx in range(n):
+            rows.append(
+                {"experiment": "A", "class": cls, "k": 1, "query_idx": q_idx, "purity": 0.5}
+            )
+    df = pd.DataFrame(rows)
+    output_path = tmp_path / "test_knn_purity_violin_degenerate.png"
+    knn_purity_violin_distribution_plot({"comparison_df": df}, output_path=output_path)
+    assert output_path.exists()
+    gc.collect()
+
+
+def test_knn_purity_violin_distribution_plot_empty(tmp_path):
+    """Empty comparison_df returns early without writing a file."""
+    output_path = tmp_path / "test_knn_purity_violin_empty.png"
+    knn_purity_violin_distribution_plot({"comparison_df": pd.DataFrame()}, output_path=output_path)
+    assert not output_path.exists()
+    gc.collect()
+
+
+def test_knn_purity_violin_distribution_plot_split_pairs_two_pairs(tmp_path):
+    """Two pairs (4 experiments) -> two split violins per k, PNG written."""
+    df = _make_per_query_df(["A1", "A2", "B1", "B2"], seed=4)
+    output_path = tmp_path / "test_knn_purity_violin_split_pairs_two.png"
+    knn_purity_violin_distribution_plot(
+        {"comparison_df": df},
+        output_path=output_path,
+        split_pairs=[["A1", "A2"], ["B1", "B2"]],
+    )
+    assert output_path.exists()
+    gc.collect()
+
+
+def test_knn_purity_violin_distribution_plot_split_pairs_one_pair_one_unpaired(tmp_path):
+    """One pair + one unpaired experiment -> split + single coexist, PNG written."""
+    df = _make_per_query_df(["A1", "A2", "C"], seed=5)
+    output_path = tmp_path / "test_knn_purity_violin_split_pairs_mixed.png"
+    knn_purity_violin_distribution_plot(
+        {"comparison_df": df},
+        output_path=output_path,
+        split_pairs=[["A1", "A2"]],
+    )
+    assert output_path.exists()
+    gc.collect()
+
+
+def test_knn_purity_violin_distribution_plot_split_pairs_missing_experiment(tmp_path):
+    """A pair naming a missing experiment warns and is skipped; PNG still written."""
+    from loguru import logger
+
+    df = _make_per_query_df(["A", "B"], seed=6)
+    output_path = tmp_path / "test_knn_purity_violin_split_pairs_missing.png"
+
+    messages: list[str] = []
+    sink_id = logger.add(lambda m: messages.append(m.record["message"]), level="WARNING")
+    try:
+        knn_purity_violin_distribution_plot(
+            {"comparison_df": df},
+            output_path=output_path,
+            split_pairs=[["A", "ghost"]],
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert any("ghost" in msg for msg in messages)
+    # The invalid pair is skipped; A and B fall through as unpaired singles.
+    assert output_path.exists()
+    gc.collect()
+
+
+def test_knn_purity_violin_distribution_plot_split_pairs_overrides_split_flag(tmp_path):
+    """split_pairs takes precedence whether split is True or False; PNG written."""
+    df = _make_per_query_df(["A1", "A2", "B1", "B2"], seed=7)
+
+    out_true = tmp_path / "test_knn_purity_violin_split_pairs_override_true.png"
+    knn_purity_violin_distribution_plot(
+        {"comparison_df": df},
+        output_path=out_true,
+        split=True,
+        split_pairs=[["A1", "A2"], ["B1", "B2"]],
+    )
+    assert out_true.exists()
+
+    out_false = tmp_path / "test_knn_purity_violin_split_pairs_override_false.png"
+    knn_purity_violin_distribution_plot(
+        {"comparison_df": df},
+        output_path=out_false,
+        split=False,
+        split_pairs=[["A1", "A2"], ["B1", "B2"]],
+    )
+    assert out_false.exists()
+    gc.collect()
+
+
+def test_knn_purity_violin_distribution_plot_split_pairs_empty(tmp_path):
+    """split_pairs=[] -> all experiments rendered as single violins, no crash."""
+    df = _make_per_query_df(["A", "B", "C"], seed=8)
+    output_path = tmp_path / "test_knn_purity_violin_split_pairs_empty.png"
+    knn_purity_violin_distribution_plot(
+        {"comparison_df": df},
+        output_path=output_path,
+        split_pairs=[],
+    )
     assert output_path.exists()
     gc.collect()
 


### PR DESCRIPTION
Added `knn_purity_violin_distribution_plot` to `COMP_PLOTS` as a drop-in alternative to the existing box-and-whisker distribution plot
Bumped to version 0.3.7, as existing configs will still work - this change is additive