### PR TITLE
Fix reprojection issue in alphaearth

### DIFF
--- a/gelos/cloud_embeddings/backends/alphaearth.py
+++ b/gelos/cloud_embeddings/backends/alphaearth.py
@@ -7,6 +7,7 @@ import threading
 from loguru import logger
 import numpy as np
 from rasterio.enums import Resampling
+from rasterio.transform import from_bounds
 from rasterio.warp import transform_bounds
 import rioxarray  # noqa: F401 — registers .rio accessor on xarray objects
 import xarray as xr
@@ -47,10 +48,16 @@ class AlphaEarthBackend:
 
     1. cache lookup keyed on ``(crs, year, bbox, out_shape)`` — short-circuits S3 if present,
     2. reproject the requested bbox to WGS84,
-    3. lazy-isel the year slab and ``.sel`` the bbox along x/y,
+    3. lazy-isel the year slab and ``.sel`` the bbox along x/y — padded by one
+       source-mosaic pixel per side when the request will be reprojected, so
+       nearest-neighbor resampling near the footprint edge always finds a real
+       source pixel instead of falling off the clipped slab into nodata,
     4. write the source CRS and nodata onto the slab via rioxarray,
     5. reproject to the requested ``crs`` (and optionally to ``out_shape``) with
-       nearest-neighbor to preserve raw embedding values,
+       nearest-neighbor to preserve raw embedding values; the output grid is
+       pinned to the request's original bbox (``from_bounds`` when ``out_shape``
+       is given, ``clip_box`` otherwise) so the padding never widens the output
+       footprint,
     6. persist the clipped + reprojected raster into the cache so re-runs and
        aggregation experiments skip the network entirely,
     7. dequantize int8 → float32 with ``-128`` mapped to NaN.
@@ -58,8 +65,11 @@ class AlphaEarthBackend:
     Cache key format is ``"mosaic_{crs}_{year}_{minx:.3f}_{miny:.3f}_{maxx:.3f}_"``
     ``"{maxy:.3f}_{8-char-sha256}.tif"``. The ``mosaic_`` prefix namespaces away
     from any pre-existing COG-era cache. The hash includes the full-precision
-    bbox tuple plus ``out_shape`` so two distinct footprints or output shapes
-    can never collide. Invalidate the cache by deleting the directory.
+    bbox tuple plus ``out_shape`` and a ``pad1`` version token (bumped when the
+    edge-padding fix landed, so pre-fix caches with false edge nodata are
+    orphaned rather than silently reused) — two distinct footprints, output
+    shapes, or extraction versions can never collide. Invalidate the cache by
+    deleting the directory.
 
     :meth:`fetch_batch` inverts the conventional chip-first loop: it iterates
     over the unique ``(year, cy, cx)`` zarr chunks touched by any uncached
@@ -256,7 +266,10 @@ class AlphaEarthBackend:
         out_shape: tuple[int, int] | None = None,
     ) -> str:
         minx, miny, maxx, maxy = bbox
-        raw = f"{crs}|{year}|{minx!r}|{miny!r}|{maxx!r}|{maxy!r}|{out_shape!r}"
+        # "pad1" versions the extraction algorithm (1-pixel edge padding +
+        # bbox-pinned output grid): bumping it orphans pre-fix cache entries
+        # whose edges hold false nodata, instead of silently reusing them.
+        raw = f"{crs}|{year}|{minx!r}|{miny!r}|{maxx!r}|{maxy!r}|{out_shape!r}|pad1"
         short_hash = hashlib.sha256(raw.encode()).hexdigest()[:8]
         safe_crs = crs.replace(":", "").replace("/", "_")
         return (
@@ -292,6 +305,33 @@ class AlphaEarthBackend:
         else:
             slab = slab.sel(y=slice(miny, maxy))
         return slab
+
+    def _pad_bbox_wgs84(
+        self, bbox: tuple[float, float, float, float]
+    ) -> tuple[float, float, float, float]:
+        """Expand a WGS84 bbox by one source-mosaic pixel step per side.
+
+        :meth:`_select_bbox` keeps only source pixels whose *centers* fall
+        inside the bbox, so an unpadded selection starves nearest-neighbor
+        reprojection at the footprint edge: a target pixel whose center lies
+        inside the request bbox can have its nearest source-pixel center just
+        *outside* the clipped slab, and rasterio then fills it with nodata.
+        One pixel of padding suffices for ``Resampling.nearest`` — any target
+        pixel center inside the bbox has its nearest source-pixel center
+        within half a source pixel of the bbox edge. Over-padding past the
+        mosaic edge is harmless: ``.sel`` clips to the coordinate range,
+        :meth:`_chunks_intersecting_bbox` clamps chunk indices, and genuinely
+        missing mosaic data stays nodata.
+        """
+        self._ensure_chunk_layout()
+        _y_chunk_px, _x_chunk_px, _y0, _x0, y_step, x_step = self._chunk_layout
+        minx, miny, maxx, maxy = bbox
+        return (
+            minx - abs(x_step),
+            miny - abs(y_step),
+            maxx + abs(x_step),
+            maxy + abs(y_step),
+        )
 
     def fetch(
         self,
@@ -345,12 +385,29 @@ class AlphaEarthBackend:
             )
 
         if req.crs != "EPSG:4326" or req.out_shape is not None:
-            sub = sub.rio.reproject(
-                req.crs,
-                resampling=Resampling.nearest,
-                nodata=self.nodata,
-                shape=req.out_shape,
-            )
+            # ``bbox_wgs84`` arrives padded by one source pixel (see
+            # _pad_bbox_wgs84), so pin the output grid to the request's
+            # ORIGINAL bbox — the pad feeds the resampler without widening
+            # the output footprint.
+            if req.out_shape is not None:
+                sub = sub.rio.reproject(
+                    req.crs,
+                    resampling=Resampling.nearest,
+                    nodata=self.nodata,
+                    shape=req.out_shape,
+                    transform=from_bounds(
+                        *req.bbox, width=req.out_shape[1], height=req.out_shape[0]
+                    ),
+                )
+            else:
+                sub = sub.rio.reproject(
+                    req.crs,
+                    resampling=Resampling.nearest,
+                    nodata=self.nodata,
+                )
+                # Mean-pool path: trim the pad ring so it can't leak into
+                # pooled statistics or the cache.
+                sub = sub.rio.clip_box(*req.bbox)
 
         if cache_path is not None:
             self.cache_dir.mkdir(parents=True, exist_ok=True)
@@ -400,12 +457,26 @@ class AlphaEarthBackend:
             )
 
             bboxes_wgs84: dict[int, tuple[float, float, float, float]] = {}
+            sel_bboxes: dict[int, tuple[float, float, float, float]] = {}
             for i in uncached:
                 req = requests[i]
                 bboxes_wgs84[i] = (
                     req.bbox
                     if req.crs == "EPSG:4326"
                     else tuple(transform_bounds(req.crs, "EPSG:4326", *req.bbox))
+                )
+                # Pad the source selection when the request will be
+                # reprojected (see _pad_bbox_wgs84). The padded bbox drives
+                # BOTH chunk intersection and slab slicing — otherwise a bbox
+                # flush against a zarr-chunk boundary would pad into a chunk
+                # that was never loaded and _select_bbox would silently clip
+                # the pad away. Pure-WGS84 pass-through stays unpadded so its
+                # output shape is unchanged.
+                needs_reproject = req.crs != "EPSG:4326" or req.out_shape is not None
+                sel_bboxes[i] = (
+                    self._pad_bbox_wgs84(bboxes_wgs84[i])
+                    if needs_reproject
+                    else bboxes_wgs84[i]
                 )
 
             if len(uncached) == 1:
@@ -415,7 +486,7 @@ class AlphaEarthBackend:
                 i = uncached[0]
                 req = requests[i]
                 year_idx = self._year_to_index(req.year)
-                chunk_pairs = self._chunks_intersecting_bbox(bboxes_wgs84[i])
+                chunk_pairs = self._chunks_intersecting_bbox(sel_bboxes[i])
                 if not chunk_pairs:
                     raise ValueError(
                         f"AlphaEarth mosaic: bbox {bboxes_wgs84[i]} "
@@ -425,14 +496,14 @@ class AlphaEarthBackend:
                     (year_idx, cy, cx): self._load_chunk(year_idx, cy, cx)
                     for (cy, cx) in sorted(chunk_pairs)
                 }
-                _, arr = self._extract_request(i, req, bboxes_wgs84[i], needed, cache_paths[i])
+                _, arr = self._extract_request(i, req, sel_bboxes[i], needed, cache_paths[i])
                 results[i] = arr
             else:
                 chunks_per_req: dict[int, set[tuple[int, int, int]]] = {}
                 chunk_to_reqs: dict[tuple[int, int, int], list[int]] = {}
                 for i in uncached:
                     year_idx = self._year_to_index(requests[i].year)
-                    chunk_pairs = self._chunks_intersecting_bbox(bboxes_wgs84[i])
+                    chunk_pairs = self._chunks_intersecting_bbox(sel_bboxes[i])
                     if not chunk_pairs:
                         raise ValueError(
                             f"AlphaEarth mosaic: bbox {bboxes_wgs84[i]} "
@@ -480,7 +551,7 @@ class AlphaEarthBackend:
                                         self._extract_request,
                                         j,
                                         requests[j],
-                                        bboxes_wgs84[j],
+                                        sel_bboxes[j],
                                         needed,
                                         cache_paths[j],
                                     )

--- a/tests/test_cloud_embeddings.py
+++ b/tests/test_cloud_embeddings.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 import rasterio
 from rasterio.transform import from_origin
+from rasterio.warp import transform_bounds
 from tests.test_data import ExampleGELOSDataSet  # noqa: F401 — resolves class_path in YAML
 from tests.utils import create_test_geojson
 import xarray as xr
@@ -630,6 +631,116 @@ def test_alphaearth_fetch_batch_empty_returns_empty(tmp_path):
     assert backend.fetch_batch([]) == []
     # data_array should remain unopened
     assert backend._da is None
+    gc.collect()
+
+
+# ---------------------------------------------------------------------------
+# AlphaEarth edge-nodata fix (padded selection + bbox-pinned output grid)
+# ---------------------------------------------------------------------------
+
+
+def test_alphaearth_utm_out_shape_has_no_edge_nodata(tmp_path):
+    """Regression: UTM fetch with out_shape must not fabricate nodata at edges.
+
+    Pre-fix, _select_bbox clipped the source slab strictly to the request
+    bbox, so nearest-neighbor reprojection filled edge target pixels (whose
+    nearest source-pixel center fell just outside the slab) with -128 → NaN.
+    The synthetic zarr has full coverage, so ANY NaN here is fabricated.
+    """
+    zarr_path = tmp_path / "synthetic.zarr"
+    _write_synthetic_zarr(zarr_path)
+    backend = AlphaEarthBackend(url=str(zarr_path), anon=False)
+    # lon -72…-71 sits in UTM zone 19N
+    bbox_utm = tuple(transform_bounds("EPSG:4326", "EPSG:32619", -71.7, 42.2, -71.5, 42.5))
+    arr = backend.fetch(bbox_utm, crs="EPSG:32619", year=2018, out_shape=(16, 16))
+    assert arr.shape == (16, 16, 64)
+    n_nan = int(np.isnan(arr[..., 0]).sum())
+    assert not np.isnan(arr).any(), f"false edge nodata: {n_nan} NaN cells in band 0"
+    gc.collect()
+
+
+def test_alphaearth_out_shape_grid_anchored_to_bbox(tmp_path):
+    """The cached tif's bounds equal the request bbox (from_bounds pinning).
+
+    The padded source selection must not widen the output footprint: the
+    16x16 output grid covers exactly the requested chip footprint.
+    """
+    zarr_path = tmp_path / "synthetic.zarr"
+    _write_synthetic_zarr(zarr_path)
+    cache_dir = tmp_path / "cache"
+    backend = AlphaEarthBackend(url=str(zarr_path), anon=False, cache_dir=cache_dir)
+    bbox_utm = tuple(transform_bounds("EPSG:4326", "EPSG:32619", -71.7, 42.2, -71.5, 42.5))
+    backend.fetch(bbox_utm, crs="EPSG:32619", year=2018, out_shape=(16, 16))
+
+    cached_files = list(cache_dir.glob("mosaic_*.tif"))
+    assert len(cached_files) == 1, f"expected one cached tif, got {cached_files}"
+    with rasterio.open(cached_files[0]) as src:
+        bounds = src.bounds
+        assert src.width == 16 and src.height == 16
+    assert bounds.left == pytest.approx(bbox_utm[0], abs=1e-6)
+    assert bounds.bottom == pytest.approx(bbox_utm[1], abs=1e-6)
+    assert bounds.right == pytest.approx(bbox_utm[2], abs=1e-6)
+    assert bounds.top == pytest.approx(bbox_utm[3], abs=1e-6)
+    gc.collect()
+
+
+def test_alphaearth_genuine_nodata_preserved(tmp_path):
+    """Padding must not fabricate data over genuine mosaic gaps.
+
+    The synthetic zarr marks the top-left source pixel (lon -72.0, lat 43.0)
+    of year 2017 as nodata. A UTM fetch covering that corner must keep NaN at
+    the corresponding output cells and stay NaN-free away from them.
+    """
+    zarr_path = tmp_path / "synthetic.zarr"
+    _write_synthetic_zarr(zarr_path, nodata_corner=True)
+    backend = AlphaEarthBackend(url=str(zarr_path), anon=False)
+    bbox_utm = tuple(transform_bounds("EPSG:4326", "EPSG:32619", -72.0, 42.9, -71.9, 43.0))
+    arr = backend.fetch(bbox_utm, crs="EPSG:32619", year=2017, out_shape=(16, 16))
+    # Output row 0 = north (lat 43), col 0 = west (lon -72): the nodata
+    # source pixel maps to the top-left output cells.
+    assert np.isnan(arr[0, 0, :]).all(), "genuine nodata at the corner was papered over"
+    # The single nodata source pixel covers only a small top-left block of
+    # the 16x16 grid; everything away from that corner must be data.
+    assert not np.isnan(arr[6:, :, :]).any()
+    assert not np.isnan(arr[:, 6:, :]).any()
+    gc.collect()
+
+
+def test_alphaearth_pad_at_mosaic_boundary(tmp_path):
+    """Bbox flush against the mosaic's outer edge: the pad is clipped, not fatal.
+
+    Padding beyond maxy=43.0 (the synthetic mosaic's top edge) must be
+    silently clipped by .sel / chunk-index clamping — no 'does not intersect'
+    and no fabricated nodata for the fully-covered footprint.
+    """
+    zarr_path = tmp_path / "synthetic.zarr"
+    _write_synthetic_zarr(zarr_path)
+    backend = AlphaEarthBackend(url=str(zarr_path), anon=False)
+    bbox_utm = tuple(transform_bounds("EPSG:4326", "EPSG:32619", -71.6, 42.9, -71.5, 43.0))
+    arr = backend.fetch(bbox_utm, crs="EPSG:32619", year=2018, out_shape=(16, 16))
+    assert arr.shape == (16, 16, 64)
+    assert not np.isnan(arr).any()
+    gc.collect()
+
+
+def test_alphaearth_pad_crosses_chunk_boundary(tmp_path):
+    """The padded bbox must drive chunk loading, not just slab slicing.
+
+    32x32 grid with 16x16 chunks: the request's WGS84 envelope ends at
+    lon -71.49, inside chunk column 0 (last center kept: pixel 15 at
+    -71.516), while the one-pixel pad reaches pixel 16 (-71.484) in chunk
+    column 1. If chunk intersection used the unpadded bbox, chunk (0, 1)
+    would never load, _select_bbox would silently clip the pad away, and the
+    right output column would come back NaN.
+    """
+    zarr_path = tmp_path / "synthetic.zarr"
+    _write_synthetic_zarr(zarr_path, H=32, W=32, chunks_yx=(16, 16))
+    backend = AlphaEarthBackend(url=str(zarr_path), anon=False)
+    bbox_utm = tuple(transform_bounds("EPSG:4326", "EPSG:32619", -71.7, 42.7, -71.49, 42.8))
+    arr = backend.fetch(bbox_utm, crs="EPSG:32619", year=2018, out_shape=(16, 16))
+    assert arr.shape == (16, 16, 64)
+    n_nan = int(np.isnan(arr[..., 0]).sum())
+    assert not np.isnan(arr).any(), f"pad did not cross chunk boundary: {n_nan} NaN cells"
     gc.collect()
 
 


### PR DESCRIPTION
The null values were caused by clipping during reprojection. The bounding box that fetches pixels has now been increased in size to avoid this happening in future. All runs with alphaearth should be re-generated after this change. Addresses #64