### PR TITLE
Rename Raw Pixels to Spectral Bands

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -290,25 +290,25 @@ comp_plots:
         - [model_B_multi, model_B_single]
 ```
 
-## Raw-pixel baseline configs
+## Spectral-band baseline configs
 
-Randomly-initialized (or mis-pretrained) foundation-model weights can still produce embedding spaces that look reasonable on downstream probes. To sanity-check how much a model is actually contributing, GELOS ships `gelos.raw_pixels.RawPixelEmbeddingTask` — a passthrough task that skips the model entirely and writes the normalized raw pixels themselves as "embeddings". The output parquets match `EmbeddingGenerationTask`'s schema, so analysis and comparison stages consume them with no special-casing.
+Randomly-initialized (or mis-pretrained) foundation-model weights can still produce embedding spaces that look reasonable on downstream probes. To sanity-check how much a model is actually contributing, GELOS ships `gelos.spectral_bands.SpectralBandsEmbeddingTask` — a passthrough task that skips the model entirely and writes the normalized spectral band values themselves as "embeddings". The output parquets match `EmbeddingGenerationTask`'s schema, so analysis and comparison stages consume them with no special-casing.
 
-Swap the `model` block for the raw task and add a top-level `raw_pixel_extraction` section:
+Swap the `model` block for the raw task and add a top-level `spectral_band_extraction` section:
 
 ```yaml
 model:
-  class_path: gelos.raw_pixels.RawPixelEmbeddingTask
-  title: "Raw Pixel Baseline"
+  class_path: gelos.spectral_bands.SpectralBandsEmbeddingTask
+  title: "Spectral Bands Baseline"
   init_args:
     patch_size: 16
     embed_file_key: filename
 
 # Each named entry becomes a per-strategy subdir under the run's output_dir
 # (playing the role of a "layer" for analysis). The product of
-# len(timesteps) * len(patches) must be <= 4 — raw pixel tokens are high-dim,
+# len(timesteps) * len(patches) must be <= 4 — spectral band tokens are high-dim,
 # so the cap keeps parquet sizes reasonable.
-raw_pixel_extraction:
+spectral_band_extraction:
   center_2x2_t0:
     title: "Center 2x2 patches, single timestep"
     patches: center_2x2      # 'center_NxN' or an explicit list of [row, col] pairs
@@ -324,6 +324,6 @@ Notes:
 - **Normalization is reused from the datamodule.** The task trusts `GELOSDataModule.aug` (defaults to z-score via means/stds) — set real per-band statistics on your dataset class or in `data.init_args.means/stds`, or baseline pixels stay un-normalized.
 - **Patch grid is derived from `H, W, patch_size`**, not configured. All of `H`, `W` must be divisible by `patch_size`, and for multi-sensor configs all sensors must share `T`, `H`, `W` after normalization (use `repeat_bands` to align single-timestep modalities like DEM).
 - **Multi-modal runs channel-concatenate per token.** Do NOT set `concat_bands: True` on the datamodule — the task handles concat itself. Sensor order follows `data.bands` YAML key order, which becomes the dict iteration order. Reordering that block between runs produces parquets of the same shape but different channel layouts.
-- **Comparison workflow.** Each modality combination is its own generation config (`raw_s2.yaml`, `raw_s2s1dem.yaml`, etc.) with its own `data.bands` and its own `raw_pixel_extraction`. Comparison configs reference raw-pixel runs by the same `(config, strategy, layer)` triple as any model run. S2 pixels getting written twice is bounded (~kB/chip per run at the 4-token cap).
+- **Comparison workflow.** Each modality combination is its own generation config (`spectral_s2.yaml`, `spectral_s2s1dem.yaml`, etc.) with its own `data.bands` and its own `spectral_band_extraction`. Comparison configs reference spectral-band runs by the same `(config, strategy, layer)` triple as any model run. S2 pixels getting written twice is bounded (~kB/chip per run at the 4-token cap).
 
-`embedding_extraction_strategies` still applies on top — each raw-pixel subdir becomes a "layer" for analysis, and each embedding-extraction strategy runs its slice/transforms/plots/models against it.
+`embedding_extraction_strategies` still applies on top — each spectral-band subdir becomes a "layer" for analysis, and each embedding-extraction strategy runs its slice/transforms/plots/models against it.

--- a/gelos/cloud_embeddings/aggregate.py
+++ b/gelos/cloud_embeddings/aggregate.py
@@ -37,7 +37,7 @@ def write_chip_parquet(
 ) -> Path:
     """Write a chip's stacked patch vectors as ``{stem}_embedding.parquet``.
 
-    Schema mirrors :func:`gelos.raw_pixels.RawPixelEmbeddingTask.write_parquet`:
+    Schema mirrors :func:`gelos.spectral_bands.SpectralBandsEmbeddingTask.write_parquet`:
     ``{"embedding": list[list[float]], "file_id": int}``.
 
     Args:

--- a/gelos/generation.py
+++ b/gelos/generation.py
@@ -130,9 +130,9 @@ def setup_embedding_run(
     yaml_config["model"].setdefault("init_args", {})
     yaml_config["model"]["init_args"]["output_dir"] = str(output_dir)
 
-    if "raw_pixel_extraction" in yaml_config:
+    if "spectral_band_extraction" in yaml_config:
         yaml_config["model"]["init_args"]["extraction_strategies"] = yaml_config[
-            "raw_pixel_extraction"
+            "spectral_band_extraction"
         ]
 
     datamodule: GELOSDataModule = instantiate_recursive(yaml_config["data"])

--- a/gelos/spectral_bands.py
+++ b/gelos/spectral_bands.py
@@ -12,8 +12,8 @@ from torchgeo.trainers import BaseTask
 from gelos.cloud_embeddings.patches import resolve_patch_indices, resolve_timestep_indices
 
 
-class RawPixelEmbeddingTask(BaseTask):
-    """Passthrough Lightning task that writes raw normalized pixels as 'embeddings'.
+class SpectralBandsEmbeddingTask(BaseTask):
+    """Passthrough Lightning task that writes normalized spectral band values as 'embeddings'.
 
     Mirrors the output layout of ``terratorch.tasks.EmbeddingGenerationTask`` so
     baseline runs flow through the existing analysis/comparison stages
@@ -67,7 +67,7 @@ class RawPixelEmbeddingTask(BaseTask):
     def _resolve_timestep_indices(self, spec: dict, T: int) -> list[int]:
         return resolve_timestep_indices(spec, T)
 
-    def _extract_raw_pixels(
+    def _extract_spectral_bands(
         self,
         name: str,
         image: torch.Tensor | dict[str, torch.Tensor],
@@ -105,7 +105,7 @@ class RawPixelEmbeddingTask(BaseTask):
         file_ids = batch.get("file_id")
 
         for name, spec in self.extraction_strategies.items():
-            tokens = self._extract_raw_pixels(name, image, spec)
+            tokens = self._extract_spectral_bands(name, image, spec)
             out_dir = self.output_path / name
             out_dir.mkdir(parents=True, exist_ok=True)
             B = tokens.shape[0]
@@ -156,4 +156,4 @@ class RawPixelEmbeddingTask(BaseTask):
         df.to_parquet(out_path, index=False)
 
 
-__all__ = ["RawPixelEmbeddingTask"]
+__all__ = ["SpectralBandsEmbeddingTask"]

--- a/tests/fixtures/example_spectral_band_config.yaml
+++ b/tests/fixtures/example_spectral_band_config.yaml
@@ -1,4 +1,4 @@
-experiment_name: "Raw Pixel Baseline - Multi-Sensor"
+experiment_name: "Spectral Bands Baseline - Multi-Sensor"
 data_version: "v0.50.1"
 chip_tracker: "gelos_chip_tracker.geojson"
 chip_id_column: "id"
@@ -46,15 +46,15 @@ data:
           n_timesteps: 4
 
 model:
-  class_path: gelos.raw_pixels.RawPixelEmbeddingTask
-  title: "Raw Pixel Baseline"
+  class_path: gelos.spectral_bands.SpectralBandsEmbeddingTask
+  title: "Spectral Bands Baseline"
   init_args:
     patch_size: 16
     embed_file_key: filename
 
 # Each named entry becomes a per-strategy subdir under output_dir.
 # The product of len(timesteps) * len(patches) must be <= 4.
-raw_pixel_extraction:
+spectral_band_extraction:
   center_2x2_t0:
     title: "Center 2x2 patches, single timestep"
     patches: center_2x2
@@ -64,11 +64,11 @@ raw_pixel_extraction:
     patches: center_1x1
     timesteps: all
 
-# Analysis picks up each raw_pixel_extraction subdir as a 'layer' and
+# Analysis picks up each spectral_band_extraction subdir as a 'layer' and
 # applies each embedding_extraction_strategies entry to it.
 embedding_extraction_strategies:
   all_tokens:
-    title: "All raw-pixel tokens"
+    title: "All spectral-band tokens"
     slice_args:
       - start: 0
         stop: null

--- a/tests/test_cloud_embeddings.py
+++ b/tests/test_cloud_embeddings.py
@@ -39,7 +39,7 @@ def _rewrite_tiff_with_transform(path: Path, transform, crs: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Shared patch resolution util (mirror of tests/test_raw_pixels.py::test_resolve_*)
+# Shared patch resolution util (mirror of tests/test_spectral_bands.py::test_resolve_*)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_spectral_bands.py
+++ b/tests/test_spectral_bands.py
@@ -10,15 +10,15 @@ import torch
 
 from gelos.analysis import run_analysis
 from gelos.generation import generate_embeddings
-from gelos.raw_pixels import RawPixelEmbeddingTask
+from gelos.spectral_bands import SpectralBandsEmbeddingTask
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def make_task(tmp_path: Path, patch_size: int = 16, strategies=None) -> RawPixelEmbeddingTask:
-    return RawPixelEmbeddingTask(
+def make_task(tmp_path: Path, patch_size: int = 16, strategies=None) -> SpectralBandsEmbeddingTask:
+    return SpectralBandsEmbeddingTask(
         output_dir=str(tmp_path),
         extraction_strategies=strategies or {},
         patch_size=patch_size,
@@ -96,7 +96,7 @@ def test_extract_shape_tensor(tmp_path):
     task = make_task(tmp_path, patch_size=16)
     image = torch.zeros((2, 3, 4, 96, 96))
     spec = {"patches": "center_2x2", "timesteps": [0]}
-    tokens = task._extract_raw_pixels("s", image, spec)
+    tokens = task._extract_spectral_bands("s", image, spec)
     assert tuple(tokens.shape) == (2, 4, 3 * 16 * 16)
 
 
@@ -108,7 +108,7 @@ def test_extract_shape_dict(tmp_path):
         "DEM": torch.zeros((2, 1, 4, 96, 96)),
     }
     spec = {"patches": "center_2x2", "timesteps": [0]}
-    tokens = task._extract_raw_pixels("s", image, spec)
+    tokens = task._extract_spectral_bands("s", image, spec)
     assert tuple(tokens.shape) == (2, 4, (6 + 2 + 1) * 16 * 16)
 
 
@@ -122,12 +122,12 @@ def test_extract_values_tensor(tmp_path):
     # [B=1, C=1, T=1, H=4, W=4] with sequential values
     image = torch.arange(16, dtype=torch.float32).reshape(1, 1, 1, 4, 4)
     spec = {"patches": [[0, 0]], "timesteps": [0]}
-    tokens = task._extract_raw_pixels("s", image, spec)
+    tokens = task._extract_spectral_bands("s", image, spec)
     # top-left 2x2 patch flattens to [0, 1, 4, 5]
     assert torch.equal(tokens[0, 0], torch.tensor([0.0, 1.0, 4.0, 5.0]))
 
     spec = {"patches": [[1, 1]], "timesteps": [0]}
-    tokens = task._extract_raw_pixels("s", image, spec)
+    tokens = task._extract_spectral_bands("s", image, spec)
     # bottom-right 2x2 patch flattens to [10, 11, 14, 15]
     assert torch.equal(tokens[0, 0], torch.tensor([10.0, 11.0, 14.0, 15.0]))
 
@@ -140,7 +140,7 @@ def test_extract_values_dict_channel_order(tmp_path):
         "C": torch.full((1, 1, 1, 4, 4), 3.0),
     }
     spec = {"patches": [[0, 0]], "timesteps": [0]}
-    tokens = task._extract_raw_pixels("s", image, spec)
+    tokens = task._extract_spectral_bands("s", image, spec)
     # flat_dim per sensor = 1*2*2 = 4 → sensor A occupies [0:4], B [4:8], C [8:12]
     assert torch.equal(tokens[0, 0, 0:4], torch.full((4,), 1.0))
     assert torch.equal(tokens[0, 0, 4:8], torch.full((4,), 2.0))
@@ -160,7 +160,7 @@ def test_dict_sensor_shape_mismatch_raises(tmp_path):
     }
     spec = {"patches": "center_1x1", "timesteps": [0]}
     with pytest.raises(ValueError, match="S1RTC"):
-        task._extract_raw_pixels("mismatch", image, spec)
+        task._extract_spectral_bands("mismatch", image, spec)
 
 
 def test_h_not_divisible_raises(tmp_path):
@@ -233,7 +233,7 @@ def test_predict_step_writes_parquet_dict(tmp_path):
 
 
 @pytest.fixture()
-def raw_pixel_run_dirs(tmp_path):
+def spectral_band_run_dirs(tmp_path):
     """Build raw_data_dir/<data_version>/ with dummy chips and return directory paths."""
     data_version = "v0.50.1"
     raw_data_dir = tmp_path / "raw"
@@ -269,18 +269,18 @@ def raw_pixel_run_dirs(tmp_path):
     }
 
 
-def test_raw_pixel_generation_e2e(raw_pixel_run_dirs):
-    yaml_path = Path(__file__).parent / "fixtures" / "example_raw_pixel_config.yaml"
+def test_spectral_band_generation_e2e(spectral_band_run_dirs):
+    yaml_path = Path(__file__).parent / "fixtures" / "example_spectral_band_config.yaml"
 
     generate_embeddings(
         yaml_path,
-        raw_data_dir=raw_pixel_run_dirs["raw_data_dir"],
-        embedding_dir=raw_pixel_run_dirs["embedding_dir"],
+        raw_data_dir=spectral_band_run_dirs["raw_data_dir"],
+        embedding_dir=spectral_band_run_dirs["embedding_dir"],
     )
 
     config_stem = yaml_path.stem
-    data_version = raw_pixel_run_dirs["data_version"]
-    output_dir = raw_pixel_run_dirs["embedding_dir"] / data_version / config_stem
+    data_version = spectral_band_run_dirs["data_version"]
+    output_dir = spectral_band_run_dirs["embedding_dir"] / data_version / config_stem
 
     for strategy in ("center_2x2_t0", "all_timesteps_center_patch"):
         strat_dir = output_dir / strategy
@@ -297,13 +297,13 @@ def test_raw_pixel_generation_e2e(raw_pixel_run_dirs):
 
     run_analysis(
         yaml_path,
-        raw_data_dir=raw_pixel_run_dirs["raw_data_dir"],
-        embedding_dir=raw_pixel_run_dirs["embedding_dir"],
-        processed_data_dir=raw_pixel_run_dirs["processed_data_dir"],
-        figures_base_dir=raw_pixel_run_dirs["figures_dir"],
+        raw_data_dir=spectral_band_run_dirs["raw_data_dir"],
+        embedding_dir=spectral_band_run_dirs["embedding_dir"],
+        processed_data_dir=spectral_band_run_dirs["processed_data_dir"],
+        figures_base_dir=spectral_band_run_dirs["figures_dir"],
     )
 
-    processed_root = raw_pixel_run_dirs["processed_data_dir"] / data_version / config_stem
+    processed_root = spectral_band_run_dirs["processed_data_dir"] / data_version / config_stem
     cached = list(processed_root.rglob("*_embeddings.npy"))
     assert cached, f"expected cached _embeddings.npy under {processed_root}"
 


### PR DESCRIPTION
This PR changes all instances of raw pixels to spectral bands. In particular, it renames gelos.raw_pixels.RawPixelEmbeddingTask  to gelos.spectral_bands.SpectralBandsEmbeddingTask. Using this version of gelos will require updating all references in existing configs to use this renamed module. As this is pre-release, I have avoided introducing aliases and adding complexity before function. I will release this under v0.5.0 to reflect this change. Addresses gelos-lc#32