### PR TITLE
Change spectral band footprints

### DIFF
--- a/gelos/cloud_embeddings/patches.py
+++ b/gelos/cloud_embeddings/patches.py
@@ -4,22 +4,19 @@ def resolve_patch_indices(spec: dict, n_rows: int, n_cols: int) -> list[tuple[in
         prefix = "center_"
         if not patches.startswith(prefix) or "x" not in patches[len(prefix) :]:
             raise ValueError(
-                f"patches string '{patches}' must match 'center_NxN' (e.g. 'center_2x2')"
+                f"patches string '{patches}' must match 'center_RxC' (e.g. 'center_1x4')"
             )
-        n_str, _, m_str = patches[len(prefix) :].partition("x")
-        if n_str != m_str:
-            raise ValueError(
-                f"patches string '{patches}' must be square (N == M); got {n_str}x{m_str}"
-            )
+        r_str, _, c_str = patches[len(prefix) :].partition("x")
         try:
-            n = int(n_str)
+            R = int(r_str)
+            C = int(c_str)
         except ValueError as exc:
-            raise ValueError(f"could not parse N from patches='{patches}'") from exc
-        if n > min(n_rows, n_cols):
-            raise ValueError(f"patches='{patches}' requires {n}x{n} but grid is {n_rows}x{n_cols}")
-        r0 = (n_rows - n) // 2
-        c0 = (n_cols - n) // 2
-        return [(r0 + dr, c0 + dc) for dr in range(n) for dc in range(n)]
+            raise ValueError(f"could not parse RxC from patches='{patches}'") from exc
+        if R > n_rows or C > n_cols:
+            raise ValueError(f"patches='{patches}' requires {R}x{C} but grid is {n_rows}x{n_cols}")
+        r0 = (n_rows - R) // 2
+        c0 = (n_cols - C) // 2
+        return [(r0 + dr, c0 + dc) for dr in range(R) for dc in range(C)]
 
     resolved: list[tuple[int, int]] = []
     for pair in patches:

--- a/tests/test_cloud_embeddings.py
+++ b/tests/test_cloud_embeddings.py
@@ -49,6 +49,13 @@ def test_resolve_patches_center_2x2():
     assert resolve_patch_indices(spec, n_rows=6, n_cols=6) == [(2, 2), (2, 3), (3, 2), (3, 3)]
 
 
+def test_resolve_patches_center_1x4():
+    spec = {"patches": "center_1x4"}
+    indices = resolve_patch_indices(spec, n_rows=6, n_cols=6)
+    # Centered horizontal line: single row, consecutive cols → contiguous row-major.
+    assert indices == [(2, 1), (2, 2), (2, 3), (2, 4)]
+
+
 def test_resolve_patches_explicit_list():
     spec = {"patches": [[0, 0], [2, 3]]}
     assert resolve_patch_indices(spec, n_rows=6, n_cols=6) == [(0, 0), (2, 3)]

--- a/tests/test_raw_pixels.py
+++ b/tests/test_raw_pixels.py
@@ -37,6 +37,32 @@ def test_resolve_center_2x2(tmp_path):
     assert indices == [(2, 2), (2, 3), (3, 2), (3, 3)]
 
 
+def test_resolve_center_1x4(tmp_path):
+    task = make_task(tmp_path)
+    spec = {"patches": "center_1x4", "timesteps": [0]}
+    indices = task._resolve_patch_indices(spec, n_rows=6, n_cols=6)
+    # r0 = (6 - 1) // 2 = 2, c0 = (6 - 4) // 2 = 1 → centered horizontal line
+    assert indices == [(2, 1), (2, 2), (2, 3), (2, 4)]
+    # Row-major contiguity: single row, consecutive columns.
+    assert len({r for r, _ in indices}) == 1
+    cols = [c for _, c in indices]
+    assert cols == list(range(cols[0], cols[0] + len(cols)))
+
+
+def test_resolve_center_1x8_col_overflow_raises(tmp_path):
+    task = make_task(tmp_path)
+    spec = {"patches": "center_1x8", "timesteps": [0]}
+    with pytest.raises(ValueError):
+        task._resolve_patch_indices(spec, n_rows=6, n_cols=6)
+
+
+def test_resolve_center_8x1_row_overflow_raises(tmp_path):
+    task = make_task(tmp_path)
+    spec = {"patches": "center_8x1", "timesteps": [0]}
+    with pytest.raises(ValueError):
+        task._resolve_patch_indices(spec, n_rows=6, n_cols=6)
+
+
 def test_resolve_center_1x1_odd_grid(tmp_path):
     task = make_task(tmp_path)
     spec = {"patches": "center_1x1", "timesteps": [0]}


### PR DESCRIPTION
This PR changes the footprint from 2x2 to 1x4 for the single time step of spectral bands. This is necessary to match the footprint of other experiments, which use 1x4 contiguous patches. Addresses gelos-lc#34