### PR TITLE
Ensure S1 and S2 normalization match models correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ gelos = {git = "https://github.com/ClarkCGA/gelos.git", tag = "v1.0.0"}
 
 ## [Unreleased]
 
+- **Analysis completion markers.** `run_analysis` now writes a `.analysis_complete` marker
+  (mirroring generation's `.embeddings_complete`) and skips fully-completed configs on
+  re-runs. Model runs (`knn`/`linear_probe`/`random_forest`) now also skip individually
+  when their results CSV and confusion-matrix figure already exist, closing the one gap in
+  the per-step caching (embeddings, transforms, metrics, and plots already skipped). New
+  `--overwrite` flag on `python -m gelos.analysis` re-enters completed runs; per-step
+  caches still apply, so only missing artifacts are recomputed — delete cached outputs for
+  a full redo.
 - **Model-matched normalization by default in `gelos.generation`.** New module
   `gelos.normalization` maps backbone names to their pretraining statistics (Prithvi EO V2,
   TerraMind v1 — imported from terratorch with hard-coded fallbacks) and required scale

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,30 @@ gelos = {git = "https://github.com/ClarkCGA/gelos.git", tag = "v1.0.0"}
 
 ## [Unreleased]
 
+- **Fix: silent normalization no-op in `GELOSDataModule`.** Stats were only looked up on
+  lowercase `means`/`stds` dataset-class attributes, so downstream classes defining uppercase
+  `MEANS`/`STDS` (e.g. gelos-lc's `GELOSLCDataSet`) silently resolved every band to mean 0.0 /
+  std 1.0, making `Normalize`/`MultimodalNormalize` an identity — models received raw pixel
+  values. Resolution order is now: explicit `means`/`stds` args → lowercase `means`/`stds`
+  class attrs → uppercase `MEANS`/`STDS` class attrs → default 0.0/1.0, and a loud
+  `logger.warning` is emitted when a modality resolves entirely to defaults.
+- New `GELOSDataModule` param `normalize: bool = True`: when `false` (and no custom `aug`),
+  `self.aug` is an identity — for backbones that apply their own pretraining normalization
+  internally (e.g. OlmoEarth).
+- New `GELOSDataModule`/`GELOSDataSet` param `db_scale_bands: dict[str, list[str]] | None`:
+  converts the listed bands from linear power to decibels (`10 * log10(clip(x, 1e-10))`) at
+  load time, before perturbation and transforms (e.g. `{"S1RTC": ["VV", "VH"]}`).
+- **Fix: OlmoEarth S1 scale mismatch + missing pretraining normalization.** The dataset's
+  S1RTC chips are linear-power gamma0 but OlmoEarth was pretrained on dB-scale S1, and its
+  pretraining data loader (not the encoder) normalized all inputs. New
+  `OlmoEarthBackbone`/factory arg `apply_pretraining_normalization: bool = True` replicates
+  that data-loader normalization exactly inside `forward_features`: S1 raw linear power →
+  clip `1e-10` → `10*log10` → per-band mean±2σ min-max; S2 raw DN (0–10000) → per-band
+  mean±2σ min-max. Stats are read from the installed `olmoearth_pretrain` package's
+  `norm_configs/computed.json` (hard-coded fallback included). **Breaking for OlmoEarth
+  configs**: inputs must now be RAW sensor scale — set `normalize: false` under
+  `data.init_args` (done in the shipped `configs/olmoearth_v1_*.yaml`) and do not apply
+  `db_scale_bands` to S1 for this backbone.
 - OlmoEarth `temporal_pooling` option on `OlmoEarthBackbone` (`model_args.temporal_pooling`):
   `mean` (default, unchanged behavior) averages tokens over timesteps; `keep` returns
   per-timestep tokens flattened time-major to `(B, T*H'*W', D)`, matching the Prithvi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ gelos = {git = "https://github.com/ClarkCGA/gelos.git", tag = "v1.0.0"}
 
 ## [Unreleased]
 
+- **Model-matched normalization by default in `gelos.generation`.** New module
+  `gelos.normalization` maps backbone names to their pretraining statistics (Prithvi EO V2,
+  TerraMind v1 — imported from terratorch with hard-coded fallbacks) and required scale
+  conversions, and `setup_embedding_run` now injects them into the datamodule config:
+  Prithvi/TerraMind get their pretraining `means`/`stds` (plus `db_scale_bands` for
+  TerraMind S1, whose stats are in dB), OlmoEarth gets `normalize: false` (its backbone
+  normalizes internally). Rationale: frozen encoders should see inputs normalized the way
+  they were pretrained, not with dataset statistics. Keys set explicitly under
+  `data.init_args` always win; unregistered models fall back to dataset statistics; a
+  registered model with a configured band that has no pretraining stat raises (override
+  with explicit `means`/`stds`).
 - **Fix: silent normalization no-op in `GELOSDataModule`.** Stats were only looked up on
   lowercase `means`/`stds` dataset-class attributes, so downstream classes defining uppercase
   `MEANS`/`STDS` (e.g. gelos-lc's `GELOSLCDataSet`) silently resolved every band to mean 0.0 /

--- a/configs/olmoearth_v1_base.yaml
+++ b/configs/olmoearth_v1_base.yaml
@@ -20,7 +20,10 @@ data:
     num_workers: 4
     # OlmoEarth is Sentinel-2 L2A only here. It requires the full 12-band S2L2A
     # set; the production GELOS-LC dataset must supply all of these (including
-    # WATER_VAPOR / B09, which ExampleGELOSDataSet does not define).
+    # WATER_VAPOR / B09, which ExampleGELOSDataSet does not define). Bands must
+    # be RAW digital numbers (0-10000) -- the backbone applies OlmoEarth's
+    # pretraining normalization internally, hence normalize: false below.
+    normalize: false
     bands:
       S2L2A:
         - COASTAL_AEROSOL   # B01

--- a/configs/olmoearth_v1_base_s1s2.yaml
+++ b/configs/olmoearth_v1_base_s1s2.yaml
@@ -19,8 +19,12 @@ data:
     batch_size: 8
     num_workers: 4
     # OlmoEarth S2+S1 mode. S2 requires the full 12-band S2L2A set (including
-    # WATER_VAPOR / B09). S1 requires VV and VH in decibel scale.
-    # NOTE: S1 data must be in decibel scale (VV mean≈-11.6 dB, VH mean≈-17.7 dB).
+    # WATER_VAPOR / B09) as RAW digital numbers (0-10000). S1 requires VV and VH
+    # as RAW LINEAR POWER gamma0 (e.g. Planetary Computer sentinel-1-rtc) -- the
+    # backbone converts S1 to dB and applies OlmoEarth's pretraining
+    # normalization to both modalities internally, hence normalize: false below.
+    # Do NOT set db_scale_bands for S1 here, or values get double-transformed.
+    normalize: false
     bands:
       S2L2A:
         - COASTAL_AEROSOL   # B01
@@ -74,7 +78,8 @@ model:
         - SWIR_1
         - SWIR_2
       # S1 bands in the order the incoming tensor presents them. Must match
-      # data.bands.S1RTC above. NOTE: S1 data must be in decibel scale.
+      # data.bands.S1RTC above. S1 input must be RAW linear power; the wrapper
+      # converts to dB and normalizes internally (apply_pretraining_normalization).
       bands_s1:
         - VV
         - VH

--- a/configs/olmoearth_v1_large.yaml
+++ b/configs/olmoearth_v1_large.yaml
@@ -20,7 +20,10 @@ data:
     num_workers: 4
     # OlmoEarth is Sentinel-2 L2A only here. It requires the full 12-band S2L2A
     # set; the production GELOS-LC dataset must supply all of these (including
-    # WATER_VAPOR / B09, which ExampleGELOSDataSet does not define).
+    # WATER_VAPOR / B09, which ExampleGELOSDataSet does not define). Bands must
+    # be RAW digital numbers (0-10000) -- the backbone applies OlmoEarth's
+    # pretraining normalization internally, hence normalize: false below.
+    normalize: false
     bands:
       S2L2A:
         - COASTAL_AEROSOL   # B01

--- a/configs/olmoearth_v1_large_s1s2.yaml
+++ b/configs/olmoearth_v1_large_s1s2.yaml
@@ -19,8 +19,12 @@ data:
     batch_size: 8
     num_workers: 4
     # OlmoEarth S2+S1 mode. S2 requires the full 12-band S2L2A set (including
-    # WATER_VAPOR / B09). S1 requires VV and VH in decibel scale.
-    # NOTE: S1 data must be in decibel scale (VV mean≈-11.6 dB, VH mean≈-17.7 dB).
+    # WATER_VAPOR / B09) as RAW digital numbers (0-10000). S1 requires VV and VH
+    # as RAW LINEAR POWER gamma0 (e.g. Planetary Computer sentinel-1-rtc) -- the
+    # backbone converts S1 to dB and applies OlmoEarth's pretraining
+    # normalization to both modalities internally, hence normalize: false below.
+    # Do NOT set db_scale_bands for S1 here, or values get double-transformed.
+    normalize: false
     bands:
       S2L2A:
         - COASTAL_AEROSOL   # B01
@@ -74,7 +78,8 @@ model:
         - SWIR_1
         - SWIR_2
       # S1 bands in the order the incoming tensor presents them. Must match
-      # data.bands.S1RTC above. NOTE: S1 data must be in decibel scale.
+      # data.bands.S1RTC above. S1 input must be RAW linear power; the wrapper
+      # converts to dB and normalizes internally (apply_pretraining_normalization).
       bands_s1:
         - VV
         - VH

--- a/configs/olmoearth_v1_nano.yaml
+++ b/configs/olmoearth_v1_nano.yaml
@@ -20,7 +20,10 @@ data:
     num_workers: 4
     # OlmoEarth is Sentinel-2 L2A only here. It requires the full 12-band S2L2A
     # set; the production GELOS-LC dataset must supply all of these (including
-    # WATER_VAPOR / B09, which ExampleGELOSDataSet does not define).
+    # WATER_VAPOR / B09, which ExampleGELOSDataSet does not define). Bands must
+    # be RAW digital numbers (0-10000) -- the backbone applies OlmoEarth's
+    # pretraining normalization internally, hence normalize: false below.
+    normalize: false
     bands:
       S2L2A:
         - COASTAL_AEROSOL   # B01

--- a/configs/olmoearth_v1_nano_s1s2.yaml
+++ b/configs/olmoearth_v1_nano_s1s2.yaml
@@ -19,8 +19,12 @@ data:
     batch_size: 8
     num_workers: 4
     # OlmoEarth S2+S1 mode. S2 requires the full 12-band S2L2A set (including
-    # WATER_VAPOR / B09). S1 requires VV and VH in decibel scale.
-    # NOTE: S1 data must be in decibel scale (VV mean≈-11.6 dB, VH mean≈-17.7 dB).
+    # WATER_VAPOR / B09) as RAW digital numbers (0-10000). S1 requires VV and VH
+    # as RAW LINEAR POWER gamma0 (e.g. Planetary Computer sentinel-1-rtc) -- the
+    # backbone converts S1 to dB and applies OlmoEarth's pretraining
+    # normalization to both modalities internally, hence normalize: false below.
+    # Do NOT set db_scale_bands for S1 here, or values get double-transformed.
+    normalize: false
     bands:
       S2L2A:
         - COASTAL_AEROSOL   # B01
@@ -74,7 +78,8 @@ model:
         - SWIR_1
         - SWIR_2
       # S1 bands in the order the incoming tensor presents them. Must match
-      # data.bands.S1RTC above. NOTE: S1 data must be in decibel scale.
+      # data.bands.S1RTC above. S1 input must be RAW linear power; the wrapper
+      # converts to dB and normalizes internally (apply_pretraining_normalization).
       bands_s1:
         - VV
         - VH

--- a/configs/olmoearth_v1_tiny.yaml
+++ b/configs/olmoearth_v1_tiny.yaml
@@ -20,7 +20,10 @@ data:
     num_workers: 4
     # OlmoEarth is Sentinel-2 L2A only here. It requires the full 12-band S2L2A
     # set; the production GELOS-LC dataset must supply all of these (including
-    # WATER_VAPOR / B09, which ExampleGELOSDataSet does not define).
+    # WATER_VAPOR / B09, which ExampleGELOSDataSet does not define). Bands must
+    # be RAW digital numbers (0-10000) -- the backbone applies OlmoEarth's
+    # pretraining normalization internally, hence normalize: false below.
+    normalize: false
     bands:
       S2L2A:
         - COASTAL_AEROSOL   # B01

--- a/configs/olmoearth_v1_tiny_s1s2.yaml
+++ b/configs/olmoearth_v1_tiny_s1s2.yaml
@@ -19,8 +19,12 @@ data:
     batch_size: 8
     num_workers: 4
     # OlmoEarth S2+S1 mode. S2 requires the full 12-band S2L2A set (including
-    # WATER_VAPOR / B09). S1 requires VV and VH in decibel scale.
-    # NOTE: S1 data must be in decibel scale (VV mean≈-11.6 dB, VH mean≈-17.7 dB).
+    # WATER_VAPOR / B09) as RAW digital numbers (0-10000). S1 requires VV and VH
+    # as RAW LINEAR POWER gamma0 (e.g. Planetary Computer sentinel-1-rtc) -- the
+    # backbone converts S1 to dB and applies OlmoEarth's pretraining
+    # normalization to both modalities internally, hence normalize: false below.
+    # Do NOT set db_scale_bands for S1 here, or values get double-transformed.
+    normalize: false
     bands:
       S2L2A:
         - COASTAL_AEROSOL   # B01
@@ -74,7 +78,8 @@ model:
         - SWIR_1
         - SWIR_2
       # S1 bands in the order the incoming tensor presents them. Must match
-      # data.bands.S1RTC above. NOTE: S1 data must be in decibel scale.
+      # data.bands.S1RTC above. S1 input must be RAW linear power; the wrapper
+      # converts to dB and normalizes internally (apply_pretraining_normalization).
       bands_s1:
         - VV
         - VH

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -149,9 +149,20 @@ style:
 | `bands` | Dict of `{sensor: [band_names]}`. Keys must match sensors in your class's `all_band_names`, values must be subsets of those band lists |
 | `repeat_bands` | Optional. Repeat static modalities (e.g., DEM) along the temporal axis to match the number of timesteps of other sensors |
 | `perturb_bands` | Optional. Add Gaussian noise for ablation experiments. Format: `{sensor: {band: weight}}` where weight ranges from 0 (no noise) to 1 (full noise) |
-| `means` / `stds` | Optional. Per-modality/band normalization statistics: `{sensor: {band: value}}`. Resolution order per band: these explicit args → lowercase `means`/`stds` class attributes on the dataset class → uppercase `MEANS`/`STDS` class attributes → default (mean 0.0, std 1.0). If an entire modality resolves to the defaults, normalization is an identity and a loud warning is logged |
-| `normalize` | Optional, default `true`. Set to `false` to skip z-score normalization entirely (identity aug) — for backbones that apply their own pretraining normalization internally, e.g. OlmoEarth |
+| `means` / `stds` | Optional. Per-modality/band normalization statistics: `{sensor: {band: value}}`. Resolution order per band: these explicit args → model-matched pretraining stats injected by `gelos.generation` (see below) → lowercase `means`/`stds` class attributes on the dataset class → uppercase `MEANS`/`STDS` class attributes → default (mean 0.0, std 1.0). If an entire modality resolves to the defaults, normalization is an identity and a loud warning is logged |
+| `normalize` | Optional, default `true`. Set to `false` to skip z-score normalization entirely (identity aug) — for backbones that apply their own pretraining normalization internally, e.g. OlmoEarth (injected automatically for OlmoEarth models, see below) |
 | `db_scale_bands` | Optional. Convert listed bands from linear power to decibels (`10 * log10(clip(x, 1e-10))`) at load time, e.g. `{S1RTC: [VV, VH]}`. Do not use together with OlmoEarth's built-in normalization, which already converts S1 to dB |
+
+**Model-matched normalization defaults.** For recognized backbones, `gelos.generation`
+automatically fills any of `means`/`stds`/`db_scale_bands`/`normalize` you did not set,
+using the model's own pretraining statistics (`gelos.normalization`): Prithvi EO V2 and
+TerraMind v1 get their published pretraining means/stds (TerraMind's S1 stats are in dB, so
+`db_scale_bands: {S1RTC: [VV, VH]}` is injected alongside), and OlmoEarth gets
+`normalize: false` because its backbone normalizes internally. Rationale: frozen encoders
+should see inputs distributed the way they were pretrained — dataset statistics are the
+fallback for models without registered stats, and anything you set explicitly in the config
+always wins. A registered model combined with a band it was not pretrained on (e.g. Prithvi
+with `COASTAL_AEROSOL`) raises an error; override with explicit `means`/`stds` if intended.
 | `transform` | Albumentations/TerraTorch transforms. Use `FlattenTemporalIntoChannels`/`UnflattenTemporalFromChannels` to apply spatial transforms across timesteps |
 
 ### Model

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -41,6 +41,17 @@ data:
     #   S2L2A:
     #     blue: 0.1
 
+    # optional: disable z-score normalization entirely (default true). Set to
+    # false for backbones that apply their own pretraining normalization
+    # internally (e.g. OlmoEarth) so the model receives raw sensor values.
+    # normalize: false
+
+    # optional: convert linear-power bands to decibels at load time
+    # (10 * log10(clip(x, 1e-10))), e.g. for models pretrained on dB-scale S1.
+    # Do NOT combine with OlmoEarth's built-in normalization (see below).
+    # db_scale_bands:
+    #   S1RTC: [VV, VH]
+
     # albumentations / terratorch transforms applied to each chip.
     # FlattenTemporalIntoChannels and UnflattenTemporalFromChannels are needed
     # to apply spatial transforms across all timesteps.
@@ -138,6 +149,9 @@ style:
 | `bands` | Dict of `{sensor: [band_names]}`. Keys must match sensors in your class's `all_band_names`, values must be subsets of those band lists |
 | `repeat_bands` | Optional. Repeat static modalities (e.g., DEM) along the temporal axis to match the number of timesteps of other sensors |
 | `perturb_bands` | Optional. Add Gaussian noise for ablation experiments. Format: `{sensor: {band: weight}}` where weight ranges from 0 (no noise) to 1 (full noise) |
+| `means` / `stds` | Optional. Per-modality/band normalization statistics: `{sensor: {band: value}}`. Resolution order per band: these explicit args → lowercase `means`/`stds` class attributes on the dataset class → uppercase `MEANS`/`STDS` class attributes → default (mean 0.0, std 1.0). If an entire modality resolves to the defaults, normalization is an identity and a loud warning is logged |
+| `normalize` | Optional, default `true`. Set to `false` to skip z-score normalization entirely (identity aug) — for backbones that apply their own pretraining normalization internally, e.g. OlmoEarth |
+| `db_scale_bands` | Optional. Convert listed bands from linear power to decibels (`10 * log10(clip(x, 1e-10))`) at load time, e.g. `{S1RTC: [VV, VH]}`. Do not use together with OlmoEarth's built-in normalization, which already converts S1 to dB |
 | `transform` | Albumentations/TerraTorch transforms. Use `FlattenTemporalIntoChannels`/`UnflattenTemporalFromChannels` to apply spatial transforms across timesteps |
 
 ### Model
@@ -185,9 +199,19 @@ Notes and limitations:
   add `S1RTC: [VV, VH]` to `data.bands` to enable S1. The S1 tensor is fused with
   the S2 embedding via equal-weight averaging. Backward compatibility: omitting
   `bands_s1` (or the S2-only model variants) requires no changes to existing configs.
-  **S1 data must be in decibel scale** — OlmoEarth pretraining used dB values
-  (VV mean≈-11.6 dB, VH mean≈-17.7 dB); linear-power S1 inputs produce incorrect
-  embeddings without raising an error. See `configs/olmoearth_v1_base_s1s2.yaml`.
+  See `configs/olmoearth_v1_base_s1s2.yaml`.
+- **Built-in pretraining normalization
+  (`model_args.apply_pretraining_normalization`, default `true`).** OlmoEarth's
+  encoder performs no normalization itself — during pretraining its data loader
+  normalized inputs. The wrapper replicates that exactly: S1 linear power is
+  clipped at `1e-10`, converted to dB (`10*log10`), then min-max scaled per band
+  over `mean±2σ`; S2 raw DN (0–10000) is min-max scaled per band over `mean±2σ`
+  (no log). Stats come from `olmoearth_pretrain`'s `computed.json`. Inputs must
+  therefore be **RAW sensor scale** (S1 linear-power gamma0, S2 L2A digital
+  numbers): set `normalize: false` under `data.init_args` and do **not** apply
+  `db_scale_bands` to S1, or values get double-transformed. Set
+  `apply_pretraining_normalization: false` only if you pre-normalize inputs to
+  OlmoEarth's pretraining scale yourself.
 - **Temporal pooling (`model_args.temporal_pooling`).** The OlmoEarth encoder
   outputs one token per (spatial patch × timestep); the wrapper controls what
   happens to the time axis. `mean` (default) averages over timesteps, returning
@@ -321,7 +345,7 @@ spectral_band_extraction:
 
 Notes:
 
-- **Normalization is reused from the datamodule.** The task trusts `GELOSDataModule.aug` (defaults to z-score via means/stds) — set real per-band statistics on your dataset class or in `data.init_args.means/stds`, or baseline pixels stay un-normalized.
+- **Normalization is reused from the datamodule.** The task trusts `GELOSDataModule.aug` (defaults to z-score via means/stds) — set real per-band statistics on your dataset class (`means`/`stds` or `MEANS`/`STDS` attributes) or in `data.init_args.means/stds`, or baseline pixels stay un-normalized (the datamodule logs a loud warning when a modality resolves entirely to default stats).
 - **Patch grid is derived from `H, W, patch_size`**, not configured. All of `H`, `W` must be divisible by `patch_size`, and for multi-sensor configs all sensors must share `T`, `H`, `W` after normalization (use `repeat_bands` to align single-timestep modalities like DEM).
 - **Multi-modal runs channel-concatenate per token.** Do NOT set `concat_bands: True` on the datamodule — the task handles concat itself. Sensor order follows `data.bands` YAML key order, which becomes the dict iteration order. Reordering that block between runs produces parquets of the same shape but different channel layouts.
 - **Comparison workflow.** Each modality combination is its own generation config (`spectral_s2.yaml`, `spectral_s2s1dem.yaml`, etc.) with its own `data.bands` and its own `spectral_band_extraction`. Comparison configs reference spectral-band runs by the same `(config, strategy, layer)` triple as any model run. S2 pixels getting written twice is bounded (~kB/chip per run at the 4-token cap).

--- a/gelos/analysis.py
+++ b/gelos/analysis.py
@@ -262,6 +262,7 @@ def run_analysis(
     embedding_dir: Path,
     processed_data_dir: Path,
     figures_base_dir: Path,
+    overwrite: bool = False,
 ) -> dict:
     """Run the config-driven embedding pipeline.
 
@@ -269,12 +270,20 @@ def run_analysis(
     and extraction strategy: extracts embeddings and dispatches through
     the configured transforms, plots, and models.
 
+    A ``.analysis_complete`` marker is written to the config's output
+    directory after a full pass; when it exists the run is skipped entirely
+    unless ``overwrite`` is set. ``overwrite`` bypasses only this marker —
+    the per-step caches (extracted embeddings, transform CSVs, metrics,
+    plots, model results) still skip individually, so a re-entered run only
+    computes what is missing. Delete the cached outputs for a full recompute.
+
     Args:
         yaml_path: Path to the YAML experiment config.
         raw_data_dir: Root directory for raw data.
         embedding_dir: Root directory for embeddings.
         processed_data_dir: Root directory for processed outputs.
         figures_base_dir: Root directory for generated figures.
+        overwrite: Re-enter a run marked complete (see above).
 
     Returns:
         Nested dict of results keyed by ``{layer}_{strategy}_{step_type}``.
@@ -282,6 +291,13 @@ def run_analysis(
     ctx = setup_analysis_run(
         yaml_path, raw_data_dir, embedding_dir, processed_data_dir, figures_base_dir
     )
+
+    marker_file = ctx.output_dir / ".analysis_complete"
+    if marker_file.exists() and not overwrite:
+        logger.info("analysis already complete, skipping...")
+        return {}
+    elif marker_file.exists() and overwrite:
+        logger.info("re-entering completed analysis (cached steps still skip)...")
 
     if not ctx.embeddings_directories:
         return {}
@@ -451,13 +467,20 @@ def run_analysis(
 
                 data = transform_results[source]
                 run_name = f"{prefix}_{m_type}"
+                layer_dir = ctx.output_dir / embedding_layer
+                # Every MODELS entry writes {run_name}_{registry_key}_results.csv
+                # (via _save_results_csv), so the cached result path is known
+                # before running.
+                results_csv = layer_dir / f"{run_name}_{m_type}_results.csv"
+                cm_path = ctx.figures_dir / f"{prefix}_{m_type}_confusion_matrix.png"
+                if results_csv.exists() and cm_path.exists():
+                    logger.info(f"model {m_type} results exist at {results_csv} - skipping")
+                    continue
                 logger.info(f"running model {m_type} for {strategy_key}")
                 m_fn = MODELS[m_type]
-                layer_dir = ctx.output_dir / embedding_layer
                 result = m_fn(data, labels, output_dir=layer_dir, run_name=run_name, **m_params)
 
                 if result.get("predictions") is not None:
-                    cm_path = ctx.figures_dir / f"{prefix}_{m_type}_confusion_matrix.png"
                     confusion_matrix(
                         predictions=result["predictions"],
                         labels=labels,
@@ -473,6 +496,9 @@ def run_analysis(
 
                 all_results[f"{prefix}_{m_type}"] = result
 
+    ctx.output_dir.mkdir(exist_ok=True, parents=True)
+    marker_file.touch()
+    logger.info("marking analysis as complete")
     return all_results
 
 
@@ -505,6 +531,12 @@ def main(
         "-c",
         help="Directory containing YAML configs (used when --yaml-path is not set).",
     ),
+    overwrite: Optional[bool] = typer.Option(
+        False,
+        "--overwrite",
+        help="Re-enter runs marked complete (.analysis_complete). Per-step caches still "
+        "skip, so only missing artifacts are recomputed; delete outputs for a full redo.",
+    ),
 ):
     """
     Analyze embeddings using transforms, plots, and models specified in a yaml config.
@@ -525,6 +557,7 @@ def main(
             embedding_dir=embedding_dir,
             processed_data_dir=processed_data_dir,
             figures_base_dir=figures_base_dir,
+            overwrite=overwrite,
         )
 
 

--- a/gelos/backbones/olmoearth_backbone.py
+++ b/gelos/backbones/olmoearth_backbone.py
@@ -26,12 +26,31 @@ S1 extension (API NOTE R2):
   S1 mask shape: (B, H, W, T, 1) — 1 band set.
   S1 output key: out["tokens_and_masks"].sentinel1, shape (B, H', W', T, 1, D).
   S2 mask shape: (B, H, W, T, 3) — 3 band sets (10m/20m/60m).
-  S1 data must be in decibel scale (VV mean≈-11.6 dB, VH mean≈-17.7 dB).
   Source: verified against allenai/olmoearth_pretrain datatypes.py and constants.py.
+
+Pretraining normalization (``apply_pretraining_normalization=True``, the default):
+  OlmoEarth was pretrained on data normalized by its own data loader (the encoder
+  itself performs no normalization), replicating
+  ``olmoearth_pretrain.data.normalize.Normalizer._normalize_computed``
+  (std_multiplier=2) and ``olmoearth_pretrain.data.utils.convert_to_db``:
+
+  - S1 (RAW LINEAR POWER in): ``clip(x, 1e-10)`` -> ``10*log10(x)`` -> per-band
+    min-max over mean±2σ: ``(x_dB - (mean - 2σ)) / (4σ)``.
+  - S2 L2A (RAW DN 0–10000 in): per-band ``(x - (mean - 2σ)) / (4σ)``, no log.
+
+  Inputs to this backbone must therefore be RAW sensor scale: S1 linear-power
+  gamma0 (e.g. Planetary Computer sentinel-1-rtc) and S2 L2A digital numbers.
+  Configure the datamodule with ``normalize: false`` and do NOT apply
+  ``db_scale_bands`` to S1, or values get double-transformed. Per-band stats are
+  read from the installed ``olmoearth_pretrain`` package's
+  ``data/norm_configs/computed.json`` when importable, else from a hard-coded
+  copy of those constants.
 """
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+import json
 import warnings
 
 import torch
@@ -62,6 +81,133 @@ OLMOEARTH_S2_BAND_ORDER: list[str] = [
 # GELOS-LC names these "VV" and "VH" (uppercase); mapping is case-insensitive.
 # S1 has 1 band set (S=1), so sentinel1_mask shape is (B, H, W, T, 1).
 OLMOEARTH_S1_BAND_ORDER: list[str] = ["vv", "vh"]
+
+# GELOS band name -> olmoearth_pretrain computed.json sentinel2_l2a band key.
+GELOS_TO_OLMOEARTH_S2_KEY: dict[str, str] = {
+    "COASTAL_AEROSOL": "B01",
+    "BLUE": "B02",
+    "GREEN": "B03",
+    "RED": "B04",
+    "RED_EDGE_1": "B05",
+    "RED_EDGE_2": "B06",
+    "RED_EDGE_3": "B07",
+    "NIR_BROAD": "B08",
+    "NIR_NARROW": "B8A",
+    "WATER_VAPOR": "B09",
+    "SWIR_1": "B11",
+    "SWIR_2": "B12",
+}
+
+# Hard-coded copy of the per-band pretraining stats from
+# olmoearth_pretrain/data/norm_configs/computed.json (keys "sentinel1" and
+# "sentinel2_l2a"), used as a fallback when the installed package cannot be read.
+_FALLBACK_COMPUTED_STATS: dict[str, dict[str, dict[str, float]]] = {
+    "sentinel1": {
+        "vv": {"mean": -11.648990747328444, "std": 10.840350299936597},
+        "vh": {"mean": -17.745436133270044, "std": 10.216274681392647},
+    },
+    "sentinel2_l2a": {
+        "B01": {"mean": 1115.8494388252218, "std": 1955.6991794280914},
+        "B02": {"mean": 1188.9412572078477, "std": 1859.1923971769581},
+        "B03": {"mean": 1407.7739105458452, "std": 1727.7387413631088},
+        "B04": {"mean": 1513.0573882432757, "std": 1740.7757298757895},
+        "B05": {"mean": 1890.9893042634167, "std": 1754.7320388511766},
+        "B06": {"mean": 2483.7812315422448, "std": 1622.1172720635755},
+        "B07": {"mean": 2722.728248756412, "std": 1621.8226170190276},
+        "B08": {"mean": 2755.481305028308, "std": 1612.2565699990187},
+        "B09": {"mean": 3269.812554170875, "std": 2651.088425085525},
+        "B11": {"mean": 2562.852607796968, "std": 1441.5471830655151},
+        "B12": {"mean": 1914.1383249044113, "std": 1328.8914382756407},
+        "B8A": {"mean": 2885.570263047681, "std": 1611.3587521042082},
+    },
+}
+
+
+def _load_computed_stats() -> dict[str, dict[str, dict[str, float]]]:
+    """Load OlmoEarth's computed normalization stats.
+
+    Prefers the ``computed.json`` shipped inside the installed
+    ``olmoearth_pretrain`` package (the authoritative source); falls back to the
+    hard-coded copy above when the package is not importable.
+    """
+    try:
+        from importlib.resources import files
+
+        with (files("olmoearth_pretrain.data.norm_configs") / "computed.json").open() as f:
+            return json.load(f)
+    except Exception:
+        return _FALLBACK_COMPUTED_STATS
+
+
+OLMOEARTH_COMPUTED_STATS: dict[str, dict[str, dict[str, float]]] = _load_computed_stats()
+
+
+def convert_to_db(x: torch.Tensor) -> torch.Tensor:
+    """Convert linear-power SAR backscatter to decibels.
+
+    Replicates ``olmoearth_pretrain.data.utils.convert_to_db``: clip to 1e-10 to
+    avoid log(0), then ``10 * log10(x)``.
+    """
+    return 10.0 * torch.log10(torch.clamp(x, min=1e-10))
+
+
+def minmax_normalize(
+    x: torch.Tensor,
+    means: Sequence[float],
+    stds: Sequence[float],
+    std_multiplier: float = 2.0,
+) -> torch.Tensor:
+    """Per-band mean±kσ min-max normalization over the last (channel) axis.
+
+    Replicates ``olmoearth_pretrain.data.normalize.Normalizer._normalize_computed``
+    with its default ``std_multiplier=2``:
+    ``(x - (mean - k*std)) / ((mean + k*std) - (mean - k*std))``.
+    """
+    mean_vals = torch.as_tensor(means, dtype=x.dtype, device=x.device)
+    std_vals = torch.as_tensor(stds, dtype=x.dtype, device=x.device)
+    min_vals = mean_vals - std_multiplier * std_vals
+    max_vals = mean_vals + std_multiplier * std_vals
+    return (x - min_vals) / (max_vals - min_vals)
+
+
+def resolve_s2_band_stats(bands: Sequence[str]) -> tuple[list[float], list[float]]:
+    """Per-band (means, stds) for GELOS-named S2 bands from computed.json.
+
+    Args:
+        bands: GELOS band names (e.g. ``"BLUE"``) in tensor channel order.
+
+    Raises:
+        ValueError: if a band has no computed.json mapping.
+    """
+    s2_stats = OLMOEARTH_COMPUTED_STATS["sentinel2_l2a"]
+    missing = [b for b in bands if b not in GELOS_TO_OLMOEARTH_S2_KEY]
+    if missing:
+        raise ValueError(
+            f"No OlmoEarth normalization stats mapping for S2 band(s) {missing}. "
+            f"Known bands: {sorted(GELOS_TO_OLMOEARTH_S2_KEY)}."
+        )
+    keys = [GELOS_TO_OLMOEARTH_S2_KEY[b] for b in bands]
+    return [s2_stats[k]["mean"] for k in keys], [s2_stats[k]["std"] for k in keys]
+
+
+def resolve_s1_band_stats(bands: Sequence[str]) -> tuple[list[float], list[float]]:
+    """Per-band (means, stds) for S1 bands (case-insensitive VV/VH) from computed.json.
+
+    Note: the computed.json sentinel1 stats are in DECIBELS — apply them to
+    dB-converted data (see :func:`convert_to_db`).
+
+    Raises:
+        ValueError: if a band is not vv/vh.
+    """
+    s1_stats = OLMOEARTH_COMPUTED_STATS["sentinel1"]
+    keys = [b.lower() for b in bands]
+    missing = [b for b, k in zip(bands, keys) if k not in s1_stats]
+    if missing:
+        raise ValueError(
+            f"No OlmoEarth normalization stats for S1 band(s) {missing}. "
+            f"Known bands: {sorted(s1_stats)}."
+        )
+    return [s1_stats[k]["mean"] for k in keys], [s1_stats[k]["std"] for k in keys]
 
 
 def build_s1_band_reorder_index(bands_s1: list[str]) -> list[int]:
@@ -129,9 +275,21 @@ class OlmoEarthBackbone(nn.Module):
 
     Accepts GELOS's channels-first ``(B, C, T, H, W)`` Sentinel-2 L2A tensor,
     reorders bands to OlmoEarth's expected 12-band order, transposes to
-    channels-last ``(B, H, W, T, C)``, runs the OlmoEarth encoder, mean-pools the
+    channels-last ``(B, H, W, T, C)``, applies OlmoEarth's pretraining
+    normalization (see below), runs the OlmoEarth encoder, mean-pools the
     token tensor over the spectral-group axis, and returns a single-element list
     ``[tokens]`` (terratorch necks expect a list of layer tensors).
+
+    With ``apply_pretraining_normalization=True`` (default), inputs must be RAW
+    sensor scale — S2 L2A digital numbers (0–10000) and S1 linear-power gamma0 —
+    and the wrapper replicates the normalization OlmoEarth's pretraining data
+    loader applied (the encoder itself has none): S1 is converted to dB
+    (``10*log10(clip(x, 1e-10))``) and both modalities are min-max scaled per
+    band over mean±2σ using ``olmoearth_pretrain``'s computed.json stats. The
+    datamodule must be configured with ``normalize: false`` and must NOT apply
+    ``db_scale_bands`` to S1, or values get double-transformed. Set
+    ``apply_pretraining_normalization=False`` only if you pre-normalize inputs
+    to OlmoEarth's pretraining scale yourself.
 
     The temporal axis is handled per ``temporal_pooling``:
 
@@ -165,6 +323,7 @@ class OlmoEarthBackbone(nn.Module):
         warn_missing_s1: bool = True,
         temporal_pooling: str = "mean",
         spatial_pooling: int | None = None,
+        apply_pretraining_normalization: bool = True,
         **kwargs,  # tolerate terratorch-injected args
     ) -> None:
         super().__init__()
@@ -201,6 +360,18 @@ class OlmoEarthBackbone(nn.Module):
         self.reorder_index_s1 = (
             build_s1_band_reorder_index(self.bands_s1) if self.bands_s1 is not None else None
         )
+
+        # Pretraining normalization stats, resolved for the POST-reorder channel
+        # order (reordering maps the configured band subset/order onto the
+        # canonical OlmoEarth orders, so stats are always indexed consistently).
+        self.apply_pretraining_normalization = apply_pretraining_normalization
+        if apply_pretraining_normalization:
+            self._s2_norm_means, self._s2_norm_stds = resolve_s2_band_stats(
+                OLMOEARTH_S2_BAND_ORDER
+            )
+            self._s1_norm_means, self._s1_norm_stds = resolve_s1_band_stats(
+                OLMOEARTH_S1_BAND_ORDER
+            )
 
         try:
             from olmoearth_pretrain.model_loader import (  # type: ignore[import-not-found]
@@ -298,6 +469,11 @@ class OlmoEarthBackbone(nn.Module):
         # 2. channels-first -> channels-last: (B, C, T, H, W) -> (B, H, W, T, C)
         x_s2 = x_s2.permute(0, 3, 4, 2, 1).contiguous()  # (B, H, W, T, 12)
 
+        # 2b. Pretraining normalization (expects RAW DN 0-10000): per-band
+        # min-max over mean±2σ, replicating olmoearth_pretrain's Normalizer.
+        if self.apply_pretraining_normalization:
+            x_s2 = minmax_normalize(x_s2, self._s2_norm_means, self._s2_norm_stds)
+
         # 3. Per-timestep timestamps (real or dummy fallback).
         timestamps = None
         if self._batch_timestamps is not None:
@@ -335,6 +511,12 @@ class OlmoEarthBackbone(nn.Module):
             idx_s1 = torch.as_tensor(self.reorder_index_s1, device=x_s1.device, dtype=torch.long)
             x_s1 = x_s1.index_select(dim=1, index=idx_s1)  # (B, 2, T, H, W)
             x_s1 = x_s1.permute(0, 3, 4, 2, 1).contiguous()  # (B, H, W, T, 2)
+            # Pretraining normalization (expects RAW LINEAR POWER): clip 1e-10 ->
+            # 10*log10 -> per-band min-max over mean±2σ (dB-scale stats).
+            if self.apply_pretraining_normalization:
+                x_s1 = minmax_normalize(
+                    convert_to_db(x_s1), self._s1_norm_means, self._s1_norm_stds
+                )
             sentinel1_tensor = x_s1
             # S1 has 1 band set -> mask shape (B, H, W, T, 1)
             sentinel1_mask = (
@@ -395,6 +577,7 @@ def olmoearth_v1_nano(
     model_id: str = "allenai/OlmoEarth-v1-Nano",
     bands: list[str] | None = None,
     patch_size: int = 4,
+    apply_pretraining_normalization: bool = True,
     hidden_dim: int | None = 128,
     **kwargs,
 ) -> OlmoEarthBackbone:
@@ -403,12 +586,18 @@ def olmoearth_v1_nano(
     Registered under its own name (``olmoearth_v1_nano``) in
     ``gelos.backbones.olmoearth_backbone``; ``BACKBONE_REGISTRY.build("olmoearth_v1_nano",
     **model_args)`` returns an :class:`OlmoEarthBackbone`.
+
+    NOTE: inputs must be RAW S2 L2A digital numbers (0-10000). With
+    ``apply_pretraining_normalization=True`` (default) the wrapper min-max
+    normalizes each band over mean±2σ, exactly as OlmoEarth's pretraining data
+    loader did. Configure the datamodule with ``normalize: false``.
     """
     return OlmoEarthBackbone(
         pretrained=pretrained,
         model_id=model_id,
         bands=bands,
         patch_size=patch_size,
+        apply_pretraining_normalization=apply_pretraining_normalization,
         hidden_dim=hidden_dim,
         **kwargs,
     )
@@ -419,6 +608,7 @@ def olmoearth_v1_tiny(
     model_id: str = "allenai/OlmoEarth-v1-Tiny",
     bands: list[str] | None = None,
     patch_size: int = 4,
+    apply_pretraining_normalization: bool = True,
     hidden_dim: int | None = 192,
     **kwargs,
 ) -> OlmoEarthBackbone:
@@ -427,12 +617,18 @@ def olmoearth_v1_tiny(
     Registered under its own name (``olmoearth_v1_tiny``) in
     ``gelos.backbones.olmoearth_backbone``; ``BACKBONE_REGISTRY.build("olmoearth_v1_tiny",
     **model_args)`` returns an :class:`OlmoEarthBackbone`.
+
+    NOTE: inputs must be RAW S2 L2A digital numbers (0-10000). With
+    ``apply_pretraining_normalization=True`` (default) the wrapper min-max
+    normalizes each band over mean±2σ, exactly as OlmoEarth's pretraining data
+    loader did. Configure the datamodule with ``normalize: false``.
     """
     return OlmoEarthBackbone(
         pretrained=pretrained,
         model_id=model_id,
         bands=bands,
         patch_size=patch_size,
+        apply_pretraining_normalization=apply_pretraining_normalization,
         hidden_dim=hidden_dim,
         **kwargs,
     )
@@ -443,6 +639,7 @@ def olmoearth_v1_base(
     model_id: str = "allenai/OlmoEarth-v1-Base",
     bands: list[str] | None = None,
     patch_size: int = 4,
+    apply_pretraining_normalization: bool = True,
     hidden_dim: int | None = 768,
     **kwargs,
 ) -> OlmoEarthBackbone:
@@ -451,12 +648,18 @@ def olmoearth_v1_base(
     Registered under its own name (``olmoearth_v1_base``) in
     ``gelos.backbones.olmoearth_backbone``; ``BACKBONE_REGISTRY.build("olmoearth_v1_base",
     **model_args)`` returns an :class:`OlmoEarthBackbone`.
+
+    NOTE: inputs must be RAW S2 L2A digital numbers (0-10000). With
+    ``apply_pretraining_normalization=True`` (default) the wrapper min-max
+    normalizes each band over mean±2σ, exactly as OlmoEarth's pretraining data
+    loader did. Configure the datamodule with ``normalize: false``.
     """
     return OlmoEarthBackbone(
         pretrained=pretrained,
         model_id=model_id,
         bands=bands,
         patch_size=patch_size,
+        apply_pretraining_normalization=apply_pretraining_normalization,
         hidden_dim=hidden_dim,
         **kwargs,
     )
@@ -467,6 +670,7 @@ def olmoearth_v1_large(
     model_id: str = "allenai/OlmoEarth-v1-Large",
     bands: list[str] | None = None,
     patch_size: int = 4,
+    apply_pretraining_normalization: bool = True,
     hidden_dim: int | None = 1024,
     **kwargs,
 ) -> OlmoEarthBackbone:
@@ -475,12 +679,18 @@ def olmoearth_v1_large(
     Registered under its own name (``olmoearth_v1_large``) in
     ``gelos.backbones.olmoearth_backbone``; ``BACKBONE_REGISTRY.build("olmoearth_v1_large",
     **model_args)`` returns an :class:`OlmoEarthBackbone`.
+
+    NOTE: inputs must be RAW S2 L2A digital numbers (0-10000). With
+    ``apply_pretraining_normalization=True`` (default) the wrapper min-max
+    normalizes each band over mean±2σ, exactly as OlmoEarth's pretraining data
+    loader did. Configure the datamodule with ``normalize: false``.
     """
     return OlmoEarthBackbone(
         pretrained=pretrained,
         model_id=model_id,
         bands=bands,
         patch_size=patch_size,
+        apply_pretraining_normalization=apply_pretraining_normalization,
         hidden_dim=hidden_dim,
         **kwargs,
     )
@@ -492,6 +702,7 @@ def olmoearth_v1_nano_s1s2(
     bands: list[str] | None = None,
     bands_s1: list[str] | None = None,
     patch_size: int = 4,
+    apply_pretraining_normalization: bool = True,
     hidden_dim: int | None = 128,
     **kwargs,
 ) -> OlmoEarthBackbone:
@@ -500,9 +711,13 @@ def olmoearth_v1_nano_s1s2(
     Pass ``bands_s1=["VV", "VH"]`` (or via YAML ``model_args.bands_s1``) to enable S1.
     Omitting ``bands_s1`` falls back to S2-only, identical to ``olmoearth_v1_nano``.
 
-    NOTE: S1 data must be in decibel scale. OlmoEarth pretraining used S1 dB values
-    (VV mean≈-11.6 dB, VH mean≈-17.7 dB). Linear-power S1 inputs produce incorrect
-    embeddings without raising an error.
+    NOTE: inputs must be RAW sensor scale — S2 L2A digital numbers (0-10000) and
+    S1 linear-power gamma0 (e.g. Planetary Computer sentinel-1-rtc). With
+    ``apply_pretraining_normalization=True`` (default) the wrapper converts S1 to
+    dB and min-max normalizes both modalities per band over mean±2σ, exactly as
+    OlmoEarth's pretraining data loader did. Configure the datamodule with
+    ``normalize: false`` and do NOT apply ``db_scale_bands`` to S1, or values get
+    double-transformed.
     """
     return OlmoEarthBackbone(
         pretrained=pretrained,
@@ -510,6 +725,7 @@ def olmoearth_v1_nano_s1s2(
         bands=bands,
         bands_s1=bands_s1,
         patch_size=patch_size,
+        apply_pretraining_normalization=apply_pretraining_normalization,
         hidden_dim=hidden_dim,
         **kwargs,
     )
@@ -521,6 +737,7 @@ def olmoearth_v1_tiny_s1s2(
     bands: list[str] | None = None,
     bands_s1: list[str] | None = None,
     patch_size: int = 4,
+    apply_pretraining_normalization: bool = True,
     hidden_dim: int | None = 192,
     **kwargs,
 ) -> OlmoEarthBackbone:
@@ -529,9 +746,13 @@ def olmoearth_v1_tiny_s1s2(
     Pass ``bands_s1=["VV", "VH"]`` (or via YAML ``model_args.bands_s1``) to enable S1.
     Omitting ``bands_s1`` falls back to S2-only, identical to ``olmoearth_v1_tiny``.
 
-    NOTE: S1 data must be in decibel scale. OlmoEarth pretraining used S1 dB values
-    (VV mean≈-11.6 dB, VH mean≈-17.7 dB). Linear-power S1 inputs produce incorrect
-    embeddings without raising an error.
+    NOTE: inputs must be RAW sensor scale — S2 L2A digital numbers (0-10000) and
+    S1 linear-power gamma0 (e.g. Planetary Computer sentinel-1-rtc). With
+    ``apply_pretraining_normalization=True`` (default) the wrapper converts S1 to
+    dB and min-max normalizes both modalities per band over mean±2σ, exactly as
+    OlmoEarth's pretraining data loader did. Configure the datamodule with
+    ``normalize: false`` and do NOT apply ``db_scale_bands`` to S1, or values get
+    double-transformed.
     """
     return OlmoEarthBackbone(
         pretrained=pretrained,
@@ -539,6 +760,7 @@ def olmoearth_v1_tiny_s1s2(
         bands=bands,
         bands_s1=bands_s1,
         patch_size=patch_size,
+        apply_pretraining_normalization=apply_pretraining_normalization,
         hidden_dim=hidden_dim,
         **kwargs,
     )
@@ -550,6 +772,7 @@ def olmoearth_v1_base_s1s2(
     bands: list[str] | None = None,
     bands_s1: list[str] | None = None,
     patch_size: int = 4,
+    apply_pretraining_normalization: bool = True,
     hidden_dim: int | None = 768,
     **kwargs,
 ) -> OlmoEarthBackbone:
@@ -558,9 +781,13 @@ def olmoearth_v1_base_s1s2(
     Pass ``bands_s1=["VV", "VH"]`` (or via YAML ``model_args.bands_s1``) to enable S1.
     Omitting ``bands_s1`` falls back to S2-only, identical to ``olmoearth_v1_base``.
 
-    NOTE: S1 data must be in decibel scale. OlmoEarth pretraining used S1 dB values
-    (VV mean≈-11.6 dB, VH mean≈-17.7 dB). Linear-power S1 inputs produce incorrect
-    embeddings without raising an error.
+    NOTE: inputs must be RAW sensor scale — S2 L2A digital numbers (0-10000) and
+    S1 linear-power gamma0 (e.g. Planetary Computer sentinel-1-rtc). With
+    ``apply_pretraining_normalization=True`` (default) the wrapper converts S1 to
+    dB and min-max normalizes both modalities per band over mean±2σ, exactly as
+    OlmoEarth's pretraining data loader did. Configure the datamodule with
+    ``normalize: false`` and do NOT apply ``db_scale_bands`` to S1, or values get
+    double-transformed.
     """
     return OlmoEarthBackbone(
         pretrained=pretrained,
@@ -568,6 +795,7 @@ def olmoearth_v1_base_s1s2(
         bands=bands,
         bands_s1=bands_s1,
         patch_size=patch_size,
+        apply_pretraining_normalization=apply_pretraining_normalization,
         hidden_dim=hidden_dim,
         **kwargs,
     )
@@ -579,6 +807,7 @@ def olmoearth_v1_large_s1s2(
     bands: list[str] | None = None,
     bands_s1: list[str] | None = None,
     patch_size: int = 4,
+    apply_pretraining_normalization: bool = True,
     hidden_dim: int | None = 1024,
     **kwargs,
 ) -> OlmoEarthBackbone:
@@ -587,9 +816,13 @@ def olmoearth_v1_large_s1s2(
     Pass ``bands_s1=["VV", "VH"]`` (or via YAML ``model_args.bands_s1``) to enable S1.
     Omitting ``bands_s1`` falls back to S2-only, identical to ``olmoearth_v1_large``.
 
-    NOTE: S1 data must be in decibel scale. OlmoEarth pretraining used S1 dB values
-    (VV mean≈-11.6 dB, VH mean≈-17.7 dB). Linear-power S1 inputs produce incorrect
-    embeddings without raising an error.
+    NOTE: inputs must be RAW sensor scale — S2 L2A digital numbers (0-10000) and
+    S1 linear-power gamma0 (e.g. Planetary Computer sentinel-1-rtc). With
+    ``apply_pretraining_normalization=True`` (default) the wrapper converts S1 to
+    dB and min-max normalizes both modalities per band over mean±2σ, exactly as
+    OlmoEarth's pretraining data loader did. Configure the datamodule with
+    ``normalize: false`` and do NOT apply ``db_scale_bands`` to S1, or values get
+    double-transformed.
     """
     return OlmoEarthBackbone(
         pretrained=pretrained,
@@ -597,6 +830,7 @@ def olmoearth_v1_large_s1s2(
         bands=bands,
         bands_s1=bands_s1,
         patch_size=patch_size,
+        apply_pretraining_normalization=apply_pretraining_normalization,
         hidden_dim=hidden_dim,
         **kwargs,
     )

--- a/gelos/gelosdatamodule.py
+++ b/gelos/gelosdatamodule.py
@@ -4,6 +4,7 @@ from typing import Any, List
 
 import albumentations as A
 from kornia.augmentation import AugmentationSequential
+from loguru import logger
 from terratorch.datamodules.generic_multimodal_data_module import (
     MultimodalNormalize,
     collate_samples,
@@ -12,6 +13,17 @@ from terratorch.datamodules.generic_multimodal_data_module import (
 from terratorch.datamodules.generic_pixel_wise_data_module import Normalize
 from torch.utils.data import DataLoader
 from torchgeo.datamodules import NonGeoDataModule
+
+
+class IdentityAug:
+    """No-op batch augmentation used when ``normalize=False``.
+
+    Returns the batch unchanged (same dict structure), for backbones that apply
+    their own pretraining normalization internally (e.g. OlmoEarth).
+    """
+
+    def __call__(self, batch: dict) -> dict:
+        return batch
 
 
 class GELOSDataModule(NonGeoDataModule):
@@ -33,6 +45,8 @@ class GELOSDataModule(NonGeoDataModule):
         concat_bands: bool = False,
         repeat_bands: dict[str, int] | None = None,
         perturb_bands: dict[str, dict[str, float]] | None = None,
+        normalize: bool = True,
+        db_scale_bands: dict[str, list[str]] | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -51,6 +65,14 @@ class GELOSDataModule(NonGeoDataModule):
             concat_bands (bool): Whether to concat all sensors into one 'image' tensor or keep separate
             repeat_bands (dict[str, int], optional): repeat bands when loading from disc, intended to repeat single time step modalities e.g. DEM
             perturb_bands (dict[str, dict[str, float]], optional): perturb bands with additive gaussian noise. Dictionary defining modalities and bands with weights for perturbation.
+            normalize (bool): When False (and no custom ``aug`` is passed), skip z-score
+                normalization entirely — ``self.aug`` is an identity. Use for backbones that
+                apply their own pretraining normalization internally (e.g. OlmoEarth).
+            db_scale_bands (dict[str, list[str]], optional): bands to convert from linear power
+                to decibels (``10 * log10(clip(x, 1e-10))``) at load time, e.g.
+                ``{"S1RTC": ["VV", "VH"]}``. Passed through to the dataset class. Do NOT use for
+                backbones that already convert S1 to dB internally (e.g. OlmoEarth with
+                ``apply_pretraining_normalization=True``).
             **kwargs: Additional keyword arguments.
         """
         if isinstance(dataset_class, str):
@@ -69,35 +91,75 @@ class GELOSDataModule(NonGeoDataModule):
         self.concat_bands = concat_bands
         self.repeat_bands = repeat_bands
         self.perturb_bands = perturb_bands
+        self.normalize = normalize
+        self.db_scale_bands = db_scale_bands
 
-        # handle passing stats with missing values, check against dataset class
-        # if none are found, mean defaults to 0 and std defaults to 1
+        # Resolve per-modality/band stats, first match wins:
+        # explicit means/stds args -> lowercase means/stds class attrs ->
+        # uppercase MEANS/STDS class attrs -> default (mean 0.0, std 1.0).
         means = means or {}
         stds = stds or {}
-        class_means = getattr(dataset_class, "means", {})
-        class_stds = getattr(dataset_class, "stds", {})
+        means_sources = (
+            means,
+            getattr(dataset_class, "means", None) or {},
+            getattr(dataset_class, "MEANS", None) or {},
+        )
+        stds_sources = (
+            stds,
+            getattr(dataset_class, "stds", None) or {},
+            getattr(dataset_class, "STDS", None) or {},
+        )
         self.means = {}
         self.stds = {}
         for modality in self.modalities:
             self.means[modality] = [
-                means.get(modality, class_means.get(modality, {})).get(band, 0.0)
+                self._resolve_stat(modality, band, means_sources, default=0.0)
                 for band in self.bands[modality]
             ]
             self.stds[modality] = [
-                stds.get(modality, class_stds.get(modality, {})).get(band, 1.0)
+                self._resolve_stat(modality, band, stds_sources, default=1.0)
                 for band in self.bands[modality]
             ]
+            if (
+                normalize
+                and aug is None
+                and modality not in means
+                and modality not in stds
+                and all(mean == 0.0 for mean in self.means[modality])
+                and all(std == 1.0 for std in self.stds[modality])
+            ):
+                logger.warning(
+                    f"No normalization statistics found for modality '{modality}' on dataset "
+                    f"class '{dataset_class.__name__}': every band resolved to mean 0.0 / "
+                    "std 1.0, so normalization will be an identity (no-op) and the model will "
+                    "receive raw pixel values. Pass explicit means/stds to GELOSDataModule or "
+                    "define means/stds (or MEANS/STDS) on the dataset class."
+                )
 
         self.transform = wrap_in_compose_is_list(transform)
-        if len(self.bands.keys()) == 1:
-            self.aug = (
-                Normalize(self.means[self.modalities[0]], self.stds[self.modalities[0]])
-                if aug is None
-                else aug
-            )
+        if aug is not None:
+            self.aug = aug
+        elif not normalize:
+            self.aug = IdentityAug()
+        elif len(self.bands.keys()) == 1:
+            self.aug = Normalize(self.means[self.modalities[0]], self.stds[self.modalities[0]])
         else:
-            self.aug = MultimodalNormalize(self.means, self.stds) if aug is None else aug
+            self.aug = MultimodalNormalize(self.means, self.stds)
         self.collate_fn = collate_samples
+
+    @staticmethod
+    def _resolve_stat(
+        modality: str,
+        band: str,
+        sources: tuple[dict[str, dict[str, float]], ...],
+        default: float,
+    ) -> float:
+        """Return the first stat found for (modality, band) across sources, else default."""
+        for source in sources:
+            value = source.get(modality, {}).get(band)
+            if value is not None:
+                return value
+        return default
 
     def setup(self, stage: str = "predict") -> None:
         """
@@ -105,6 +167,11 @@ class GELOSDataModule(NonGeoDataModule):
         """
         if stage != "predict":
             raise ValueError("GELOS dataset is for prediction only")
+        # Only forward db_scale_bands when set, so dataset subclasses that predate
+        # the parameter keep working as long as the feature is unused.
+        extra_kwargs = {}
+        if self.db_scale_bands is not None:
+            extra_kwargs["db_scale_bands"] = self.db_scale_bands
         self.dataset = self.dataset_class(
             data_root=self.data_root,
             bands=self.bands,
@@ -112,6 +179,7 @@ class GELOSDataModule(NonGeoDataModule):
             concat_bands=self.concat_bands,
             repeat_bands=self.repeat_bands,
             perturb_bands=self.perturb_bands,
+            **extra_kwargs,
         )
 
     def _dataloader_factory(self, stage: str = "predict"):

--- a/gelos/gelosdataset.py
+++ b/gelos/gelosdataset.py
@@ -54,6 +54,7 @@ class GELOSDataSet(NonGeoDataset):
         concat_bands: bool = False,
         repeat_bands: dict[str, int] | None = None,
         perturb_bands: dict[str, dict[str, float]] | None = None,
+        db_scale_bands: dict[str, list[str]] | None = None,
     ) -> None:
 
         self.bands = bands
@@ -61,6 +62,7 @@ class GELOSDataSet(NonGeoDataset):
         self.concat_bands = concat_bands
         self.repeat_bands = repeat_bands
         self.perturb_bands = perturb_bands
+        self.db_scale_bands = db_scale_bands
 
         assert set(self.bands.keys()).issubset(set(self.all_band_names.keys())), (
             f"Please choose a subset of valid sensors: {self.all_band_names.keys()}"
@@ -104,6 +106,17 @@ class GELOSDataSet(NonGeoDataset):
         for sensor in self.bands.keys():
             image = self._load_sensor_images(index, sensor)
             output[sensor] = image.astype(np.float32)
+
+        # Convert linear-power bands to decibels right after loading, before any
+        # perturbation or transforms. Matches olmoearth_pretrain's convert_to_db:
+        # clip to 1e-10 to avoid log(0), then 10 * log10(x).
+        if self.db_scale_bands:
+            for sensor, db_band_list in self.db_scale_bands.items():
+                band_indices = [self.bands[sensor].index(band) for band in db_band_list]
+                for band_index in band_indices:
+                    output[sensor][..., band_index] = 10 * np.log10(
+                        np.clip(output[sensor][..., band_index], 1e-10, None)
+                    )
 
         if self.repeat_bands:
             for sensor, repeats in self.repeat_bands.items():

--- a/gelos/generation.py
+++ b/gelos/generation.py
@@ -10,6 +10,7 @@ import typer
 import yaml
 
 from gelos.gelosdatamodule import GELOSDataModule
+from gelos.normalization import inject_model_normalization
 
 try:
     import gelos.backbones.olmoearth_backbone  # noqa: F401 — registers OlmoEarth factories
@@ -134,6 +135,10 @@ def setup_embedding_run(
         yaml_config["model"]["init_args"]["extraction_strategies"] = yaml_config[
             "spectral_band_extraction"
         ]
+
+    model_name = yaml_config["model"]["init_args"].get("model")
+    if isinstance(model_name, str):
+        inject_model_normalization(yaml_config["data"].setdefault("init_args", {}), model_name)
 
     datamodule: GELOSDataModule = instantiate_recursive(yaml_config["data"])
 

--- a/gelos/normalization.py
+++ b/gelos/normalization.py
@@ -1,0 +1,195 @@
+"""Model-matched normalization defaults for embedding generation.
+
+Frozen encoders should receive inputs normalized the way the model saw data
+during pretraining, not with dataset statistics: the full preprocessing chain
+(raw sensor values -> scaled tensor) is effectively the model's first layer.
+This module maps backbone names to their pretraining statistics (keyed by
+GELOS band names) plus any required scale conversions (e.g. Sentinel-1 linear
+power -> dB), and ``gelos.generation`` injects them into the datamodule config
+for recognized models. Keys set explicitly in the config always win, and
+unrecognized models fall back to the dataset-statistics resolution in
+``GELOSDataModule``.
+
+Statistics are imported from terratorch where available so they stay in sync;
+hard-coded fallbacks (copied from the same terratorch modules) cover older
+terratorch layouts.
+"""
+
+from loguru import logger
+
+try:
+    from terratorch.models.backbones.prithvi_vit import PRITHVI_V2_MEAN, PRITHVI_V2_STD
+except ImportError:  # terratorch layout changed; values from prithvi_vit.py
+    PRITHVI_V2_MEAN = [1087.0, 1342.0, 1433.0, 2734.0, 1958.0, 1363.0]
+    PRITHVI_V2_STD = [2248.0, 2179.0, 2178.0, 1850.0, 1242.0, 1049.0]
+
+try:
+    from terratorch.models.backbones.terramind.model.terramind_register import (
+        v1_pretraining_mean as _tm_v1_mean,
+    )
+    from terratorch.models.backbones.terramind.model.terramind_register import (
+        v1_pretraining_std as _tm_v1_std,
+    )
+
+    _TM_S2L2A_MEAN = _tm_v1_mean["untok_sen2l2a@224"]
+    _TM_S2L2A_STD = _tm_v1_std["untok_sen2l2a@224"]
+    _TM_S1RTC_MEAN = _tm_v1_mean["untok_sen1rtc@224"]
+    _TM_S1RTC_STD = _tm_v1_std["untok_sen1rtc@224"]
+    _TM_DEM_MEAN = _tm_v1_mean["untok_dem@224"]
+    _TM_DEM_STD = _tm_v1_std["untok_dem@224"]
+except ImportError:  # terratorch layout changed; values from terramind_register.py
+    _TM_S2L2A_MEAN = [
+        1390.458, 1503.317, 1718.197, 1853.91, 2199.1, 2779.975,
+        2987.011, 3083.234, 3132.22, 3162.988, 2424.884, 1857.648,
+    ]  # fmt: skip
+    _TM_S2L2A_STD = [
+        2106.761, 2141.107, 2038.973, 2134.138, 2085.321, 1889.926,
+        1820.257, 1871.918, 1753.829, 1797.379, 1434.261, 1334.311,
+    ]  # fmt: skip
+    _TM_S1RTC_MEAN = [-10.93, -17.329]
+    _TM_S1RTC_STD = [4.391, 4.459]
+    _TM_DEM_MEAN = [670.665]
+    _TM_DEM_STD = [951.272]
+
+# Band orders below mirror terratorch's PRETRAINED_BANDS for each backbone.
+_PRITHVI_BANDS = ["BLUE", "GREEN", "RED", "NIR_NARROW", "SWIR_1", "SWIR_2"]
+_TERRAMIND_S2L2A_BANDS = [
+    "COASTAL_AEROSOL",
+    "BLUE",
+    "GREEN",
+    "RED",
+    "RED_EDGE_1",
+    "RED_EDGE_2",
+    "RED_EDGE_3",
+    "NIR_BROAD",
+    "NIR_NARROW",
+    "WATER_VAPOR",
+    "SWIR_1",
+    "SWIR_2",
+]
+
+
+def _band_stats(bands: list[str], values: list[float]) -> dict[str, float]:
+    if len(bands) != len(values):
+        raise ValueError(f"band/stat length mismatch: {bands} vs {values}")
+    return dict(zip(bands, values))
+
+
+# Backbone-name prefix -> normalization spec. A spec is either
+# {"normalize": False} (the backbone normalizes internally, e.g. OlmoEarth) or
+# per-modality pretraining stats with optional dB conversion requirements.
+MODEL_NORMALIZATION = {
+    "prithvi_eo_v2": {
+        "means": {"S2L2A": _band_stats(_PRITHVI_BANDS, PRITHVI_V2_MEAN)},
+        "stds": {"S2L2A": _band_stats(_PRITHVI_BANDS, PRITHVI_V2_STD)},
+    },
+    "terramind_v1": {
+        "means": {
+            "S2L2A": _band_stats(_TERRAMIND_S2L2A_BANDS, _TM_S2L2A_MEAN),
+            "S1RTC": _band_stats(["VV", "VH"], _TM_S1RTC_MEAN),
+            "DEM": _band_stats(["DEM"], _TM_DEM_MEAN),
+        },
+        "stds": {
+            "S2L2A": _band_stats(_TERRAMIND_S2L2A_BANDS, _TM_S2L2A_STD),
+            "S1RTC": _band_stats(["VV", "VH"], _TM_S1RTC_STD),
+            "DEM": _band_stats(["DEM"], _TM_DEM_STD),
+        },
+        # TerraMind's S1 pretraining stats are in dB; the on-disk chips are
+        # linear power, so the datamodule must convert before normalizing.
+        "db_scale_bands": {"S1RTC": ["VV", "VH"]},
+    },
+    "olmoearth_v1": {"normalize": False},
+}
+
+
+def resolve_model_normalization(
+    model_name: str, bands: dict[str, list[str]]
+) -> dict[str, object] | None:
+    """Resolve datamodule kwargs matching a backbone's pretraining normalization.
+
+    Args:
+        model_name: terratorch/gelos backbone name (e.g. ``prithvi_eo_v2_300``).
+        bands: modality -> band names, as configured on the datamodule.
+
+    Returns:
+        Dict of ``GELOSDataModule`` init kwargs (``means``/``stds`` and
+        optionally ``db_scale_bands``, or ``normalize: False`` for backbones
+        that normalize internally), or ``None`` if the model is not registered.
+
+    Raises:
+        ValueError: the model is registered but a configured modality or band
+            has no pretraining statistic. Set ``means``/``stds`` explicitly in
+            the config to override.
+    """
+    spec = next(
+        (s for prefix, s in MODEL_NORMALIZATION.items() if model_name.startswith(prefix)),
+        None,
+    )
+    if spec is None:
+        return None
+    if "normalize" in spec:
+        return {"normalize": spec["normalize"]}
+
+    means: dict[str, dict[str, float]] = {}
+    stds: dict[str, dict[str, float]] = {}
+    for modality, band_list in bands.items():
+        model_means = spec["means"].get(modality)
+        if model_means is None:
+            raise ValueError(
+                f"{model_name} has no pretraining statistics for modality '{modality}'; "
+                "set means/stds for it explicitly in the config to override"
+            )
+        missing = [band for band in band_list if band not in model_means]
+        if missing:
+            raise ValueError(
+                f"{model_name} has no pretraining statistics for {modality} bands {missing}; "
+                "set means/stds for them explicitly in the config to override"
+            )
+        means[modality] = {band: model_means[band] for band in band_list}
+        stds[modality] = {band: spec["stds"][modality][band] for band in band_list}
+
+    resolved: dict[str, object] = {"means": means, "stds": stds}
+    db_scale = {
+        modality: [b for b in band_list if b in spec.get("db_scale_bands", {}).get(modality, [])]
+        for modality, band_list in bands.items()
+    }
+    db_scale = {modality: band_list for modality, band_list in db_scale.items() if band_list}
+    if db_scale:
+        resolved["db_scale_bands"] = db_scale
+    return resolved
+
+
+def inject_model_normalization(data_init_args: dict, model_name: str) -> list[str]:
+    """Inject model-matched normalization defaults into a datamodule config dict.
+
+    Mutates ``data_init_args`` in place. Keys already present in the config are
+    never overwritten, so explicit config values always win.
+
+    Returns:
+        The list of injected keys (empty if the model is unregistered, the
+        config left no gaps to fill, or no ``bands`` are configured).
+    """
+    bands = data_init_args.get("bands")
+    if not bands:
+        logger.warning(
+            f"no explicit 'bands' in the data config; cannot resolve model-matched "
+            f"normalization for '{model_name}' — falling back to dataset statistics"
+        )
+        return []
+    resolved = resolve_model_normalization(model_name, bands)
+    if resolved is None:
+        logger.info(
+            f"no model-matched normalization registered for '{model_name}'; "
+            "falling back to dataset statistics"
+        )
+        return []
+    injected = [key for key in resolved if key not in data_init_args]
+    for key in injected:
+        data_init_args[key] = resolved[key]
+    if injected:
+        logger.info(f"model-matched normalization for '{model_name}': injected {injected}")
+    else:
+        logger.info(
+            f"model-matched normalization for '{model_name}' fully overridden by the config"
+        )
+    return injected

--- a/tests/fixtures/example_olmoearth_config.yaml
+++ b/tests/fixtures/example_olmoearth_config.yaml
@@ -24,7 +24,10 @@ data:
     # requires. A real smoke run therefore needs a dataset that supplies the full
     # 12-band S2L2A set (see configs/olmoearth_v1_base.yaml). The 11 bands the
     # example dataset does provide are listed here for shape; the wrapper raises a
-    # clear ValueError on the missing WATER_VAPOR band.
+    # clear ValueError on the missing WATER_VAPOR band. Bands must be RAW digital
+    # numbers — the backbone applies OlmoEarth's pretraining normalization
+    # internally, hence normalize: false below.
+    normalize: false
     bands:
       S2L2A:
         - coastal

--- a/tests/fixtures/example_olmoearth_s1s2_config.yaml
+++ b/tests/fixtures/example_olmoearth_s1s2_config.yaml
@@ -22,8 +22,11 @@ data:
     # production 12-band GELOS-LC dataset for live inference. ExampleGELOSDataSet
     # defines only 11 S2L2A bands and lacks WATER_VAPOR (B09), which OlmoEarth
     # requires. A real smoke run therefore needs a dataset that supplies the full
-    # 12-band S2L2A set and S1RTC with VV/VH bands in decibel scale.
-    # NOTE: S1 data must be in decibel scale (VV mean≈-11.6 dB, VH mean≈-17.7 dB).
+    # 12-band S2L2A set and S1RTC with VV/VH bands as RAW LINEAR POWER — the
+    # backbone converts S1 to dB and applies OlmoEarth's pretraining
+    # normalization internally, hence normalize: false below. Do NOT set
+    # db_scale_bands for S1 here, or values get double-transformed.
+    normalize: false
     bands:
       S2L2A:
         - coastal
@@ -72,8 +75,8 @@ model:
         - nir08
         - swir16
         - swir22
-      # S1 bands in the order the incoming tensor presents them.
-      # NOTE: S1 data must be in decibel scale.
+      # S1 bands in the order the incoming tensor presents them. S1 input must be
+      # RAW linear power; the wrapper converts to dB and normalizes internally.
       bands_s1:
         - VV
         - VH

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -742,3 +742,85 @@ def test_temporal_cosine_similarity_invalid_timesteps():
     with pytest.raises(ValueError, match="n_timesteps must be an int > 1"):
         temporal_cosine_similarity(*dummy_args, n_timesteps="four")
     gc.collect()
+
+
+# ---------------------------------------------------------------------------
+# Tests: run_analysis completion marker + model result skipping
+# ---------------------------------------------------------------------------
+
+
+def _marker_ctx(tmp_path, synthetic_labels):
+    """Build a minimal AnalysisContext for run_analysis marker tests."""
+    from gelos.analysis import AnalysisContext
+
+    chip_gdf = gpd.GeoDataFrame(
+        {
+            "id": list(range(N_SAMPLES)),
+            "lulc": synthetic_labels,
+            "geometry": [Point(float(i), float(i)) for i in range(N_SAMPLES)],
+        },
+        crs="EPSG:4326",
+    ).set_index("id")
+    emb_dir = tmp_path / "embeddings" / "layer_-1"
+    emb_dir.mkdir(parents=True)
+    return AnalysisContext(
+        yaml_config={},
+        config_stem="exptest",
+        experiment_name="marker test",
+        style_cfg={"category_column": "lulc", "colors": {}, "labels": {}},
+        category_column="lulc",
+        embedding_extraction_strategies={
+            "strategy": {
+                "slice_args": [{"start": 0, "stop": 1, "step": 1}],
+                "transforms": [{"type": "pca", "params": {"n_components": 2}}],
+                "models": [{"type": "knn", "transform": "pca", "params": {"n_splits": 2}}],
+            }
+        },
+        chip_gdf=chip_gdf,
+        input_dir=tmp_path / "embeddings",
+        output_dir=tmp_path / "processed",
+        figures_dir=tmp_path / "figures",
+        null_handling="drop",
+        embeddings_directories=[emb_dir],
+    )
+
+
+def test_run_analysis_marker_and_model_skip(
+    tmp_path, synthetic_embeddings, synthetic_labels, monkeypatch
+):
+    """Second run skips via .analysis_complete; overwrite re-enters but cached models skip."""
+    import gelos.analysis as analysis_mod
+
+    embeddings, chip_indices = synthetic_embeddings
+    ctx = _marker_ctx(tmp_path, synthetic_labels)
+    ctx.figures_dir.mkdir(parents=True)
+    monkeypatch.setattr(analysis_mod, "setup_analysis_run", lambda *a, **k: ctx)
+    extract_calls = []
+
+    def fake_extract(directory, slice_args):
+        extract_calls.append(directory)
+        return embeddings, chip_indices
+
+    monkeypatch.setattr(analysis_mod, "extract_embeddings", fake_extract)
+    args = (tmp_path / "cfg.yaml", tmp_path, tmp_path, tmp_path, tmp_path)
+
+    results = analysis_mod.run_analysis(*args)
+    marker = ctx.output_dir / ".analysis_complete"
+    assert marker.exists()
+    assert len(extract_calls) == 1
+    assert any(key.endswith("_knn") for key in results)
+    model_csv = ctx.output_dir / "layer_-1" / "exptest_strategy_layer_-1_knn_knn_results.csv"
+    assert model_csv.exists()
+
+    # Second run: marker short-circuits everything.
+    assert analysis_mod.run_analysis(*args) == {}
+    assert len(extract_calls) == 1
+
+    # Overwrite: re-enters, but embeddings come from cache and the cached model
+    # result (results CSV + confusion matrix) is not recomputed.
+    csv_mtime = model_csv.stat().st_mtime_ns
+    results = analysis_mod.run_analysis(*args, overwrite=True)
+    assert len(extract_calls) == 1  # .npy cache hit, no re-extraction
+    assert results == {}  # model skipped, nothing recomputed
+    assert model_csv.stat().st_mtime_ns == csv_mtime
+    gc.collect()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -102,6 +102,7 @@ class ExampleGELOSDataSet(GELOSDataSet):
         concat_bands: bool = False,
         repeat_bands: dict[str, int] | None = None,
         perturb_bands: dict[str, dict[str, float]] | None = None,
+        db_scale_bands: dict[str, list[str]] | None = None,
     ) -> None:
         if bands is None:
             bands = self.all_band_names
@@ -113,6 +114,7 @@ class ExampleGELOSDataSet(GELOSDataSet):
             concat_bands=concat_bands,
             repeat_bands=repeat_bands,
             perturb_bands=perturb_bands,
+            db_scale_bands=db_scale_bands,
         )
 
         self.data_root = Path(data_root)
@@ -361,6 +363,238 @@ def test_datamodule_setup_and_iterate(data_root):
     assert "image" in batch
     assert "filename" in batch
     assert "file_id" in batch
+    gc.collect()
+
+
+# ---------------------------------------------------------------------------
+# Tests: normalization stats resolution (explicit args -> means/stds ->
+# MEANS/STDS -> defaults) and the identity-normalization warning
+# ---------------------------------------------------------------------------
+
+
+class _UppercaseStatsDataSet:
+    """Minimal dataset-class stand-in defining only uppercase MEANS/STDS."""
+
+    all_band_names = {"S2L2A": ["blue", "green"]}
+    MEANS = {"S2L2A": {"blue": 10.0, "green": 20.0}}
+    STDS = {"S2L2A": {"blue": 2.0, "green": 4.0}}
+
+
+class _BothCaseStatsDataSet:
+    """Defines both cases; lowercase means/stds must win over MEANS/STDS."""
+
+    all_band_names = {"S2L2A": ["blue"]}
+    means = {"S2L2A": {"blue": 1.0}}
+    stds = {"S2L2A": {"blue": 3.0}}
+    MEANS = {"S2L2A": {"blue": 100.0}}
+    STDS = {"S2L2A": {"blue": 300.0}}
+
+
+class _NoStatsDataSet:
+    """No stats attributes at all: every band resolves to the 0.0/1.0 defaults."""
+
+    all_band_names = {"S2L2A": ["blue", "green"]}
+
+
+def _capture_loguru_warnings():
+    """Return (messages, sink_id): a list capturing loguru WARNING+ output."""
+    from loguru import logger
+
+    messages = []
+    sink_id = logger.add(lambda message: messages.append(str(message)), level="WARNING")
+    return messages, sink_id
+
+
+def test_stats_resolution_uppercase_class_attrs():
+    """Uppercase MEANS/STDS class attributes are found (the gelos-lc convention)."""
+    dm = GELOSDataModule(
+        data_root="unused",
+        batch_size=1,
+        num_workers=0,
+        dataset_class=_UppercaseStatsDataSet,
+        bands={"S2L2A": ["blue", "green"]},
+    )
+    assert dm.means["S2L2A"] == [10.0, 20.0]
+    assert dm.stds["S2L2A"] == [2.0, 4.0]
+
+
+def test_stats_resolution_lowercase_wins_over_uppercase():
+    """Lowercase means/stds class attributes take precedence over MEANS/STDS."""
+    dm = GELOSDataModule(
+        data_root="unused",
+        batch_size=1,
+        num_workers=0,
+        dataset_class=_BothCaseStatsDataSet,
+        bands={"S2L2A": ["blue"]},
+    )
+    assert dm.means["S2L2A"] == [1.0]
+    assert dm.stds["S2L2A"] == [3.0]
+
+
+def test_stats_resolution_explicit_args_win():
+    """Explicit means/stds arguments take precedence over any class attributes."""
+    dm = GELOSDataModule(
+        data_root="unused",
+        batch_size=1,
+        num_workers=0,
+        dataset_class=_BothCaseStatsDataSet,
+        bands={"S2L2A": ["blue"]},
+        means={"S2L2A": {"blue": 7.0}},
+        stds={"S2L2A": {"blue": 9.0}},
+    )
+    assert dm.means["S2L2A"] == [7.0]
+    assert dm.stds["S2L2A"] == [9.0]
+
+
+def test_stats_resolution_all_defaults_warns():
+    """A modality resolving entirely to defaults logs a loud identity warning."""
+    messages, sink_id = _capture_loguru_warnings()
+    from loguru import logger
+
+    try:
+        dm = GELOSDataModule(
+            data_root="unused",
+            batch_size=1,
+            num_workers=0,
+            dataset_class=_NoStatsDataSet,
+            bands={"S2L2A": ["blue", "green"]},
+        )
+    finally:
+        logger.remove(sink_id)
+    assert dm.means["S2L2A"] == [0.0, 0.0]
+    assert dm.stds["S2L2A"] == [1.0, 1.0]
+    assert any(
+        "identity" in message and "_NoStatsDataSet" in message and "S2L2A" in message
+        for message in messages
+    )
+
+
+def test_stats_resolution_real_stats_do_not_warn():
+    """No identity warning when real statistics are resolved."""
+    messages, sink_id = _capture_loguru_warnings()
+    from loguru import logger
+
+    try:
+        GELOSDataModule(
+            data_root="unused",
+            batch_size=1,
+            num_workers=0,
+            dataset_class=_UppercaseStatsDataSet,
+            bands={"S2L2A": ["blue", "green"]},
+        )
+    finally:
+        logger.remove(sink_id)
+    assert not any("identity" in message for message in messages)
+
+
+# ---------------------------------------------------------------------------
+# Tests: normalize=False (identity aug)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_false_aug_is_identity(data_root):
+    """With normalize=False the aug leaves a batch completely unchanged."""
+    import copy
+
+    dm = GELOSDataModule(
+        data_root=data_root,
+        batch_size=2,
+        num_workers=0,
+        dataset_class=ExampleGELOSDataSet,
+        bands={"S2L2A": ["blue", "green", "red"], "DEM": ["DEM"]},
+        means={"S2L2A": {"blue": 5.0, "green": 5.0, "red": 5.0}, "DEM": {"DEM": 5.0}},
+        stds={"S2L2A": {"blue": 2.0, "green": 2.0, "red": 2.0}, "DEM": {"DEM": 2.0}},
+        normalize=False,
+    )
+    dm.setup(stage="predict")
+    batch = next(iter(dm.predict_dataloader()))
+    original = copy.deepcopy(batch)
+    out = dm.aug(batch)
+    for sensor in ("S2L2A", "DEM"):
+        torch.testing.assert_close(out["image"][sensor], original["image"][sensor])
+    gc.collect()
+
+
+def test_normalize_true_aug_changes_batch(data_root):
+    """Control: with normalize=True and real stats, the aug does modify the batch."""
+    import copy
+
+    dm = GELOSDataModule(
+        data_root=data_root,
+        batch_size=2,
+        num_workers=0,
+        dataset_class=ExampleGELOSDataSet,
+        bands={"S2L2A": ["blue", "green", "red"], "DEM": ["DEM"]},
+        means={"S2L2A": {"blue": 5.0, "green": 5.0, "red": 5.0}, "DEM": {"DEM": 5.0}},
+        stds={"S2L2A": {"blue": 2.0, "green": 2.0, "red": 2.0}, "DEM": {"DEM": 2.0}},
+    )
+    dm.setup(stage="predict")
+    batch = next(iter(dm.predict_dataloader()))
+    original = copy.deepcopy(batch)
+    out = dm.aug(batch)
+    assert not torch.equal(out["image"]["S2L2A"], original["image"]["S2L2A"])
+    gc.collect()
+
+
+# ---------------------------------------------------------------------------
+# Tests: db_scale_bands (linear power -> decibel conversion)
+# ---------------------------------------------------------------------------
+
+
+def test_db_scale_bands_converts_to_decibels(data_root):
+    """db_scale_bands output equals 10*log10(clip(raw, 1e-10)) of the raw output."""
+    bands = {"S1RTC": ["VV", "VH"]}
+    raw_ds = ExampleGELOSDataSet(data_root=data_root, bands=bands)
+    db_ds = ExampleGELOSDataSet(
+        data_root=data_root, bands=bands, db_scale_bands={"S1RTC": ["VV", "VH"]}
+    )
+    raw = raw_ds[0]["image"]
+    db = db_ds[0]["image"]
+    expected = 10 * torch.log10(torch.clamp(raw, min=1e-10))
+    torch.testing.assert_close(db, expected)
+    gc.collect()
+
+
+def test_db_scale_bands_converts_only_listed_bands(data_root):
+    """Bands not listed in db_scale_bands are untouched."""
+    bands = {"S1RTC": ["VV", "VH"]}
+    raw_ds = ExampleGELOSDataSet(data_root=data_root, bands=bands)
+    db_ds = ExampleGELOSDataSet(
+        data_root=data_root, bands=bands, db_scale_bands={"S1RTC": ["VV"]}
+    )
+    raw = raw_ds[0]["image"]
+    db = db_ds[0]["image"]
+    # Band layout is [C, T, H, W]: VV is channel 0, VH channel 1.
+    torch.testing.assert_close(db[0], 10 * torch.log10(torch.clamp(raw[0], min=1e-10)))
+    torch.testing.assert_close(db[1], raw[1])
+    gc.collect()
+
+
+def test_db_scale_bands_invalid_band_raises(data_root):
+    """Band names are validated against self.bands like perturb_bands."""
+    ds = ExampleGELOSDataSet(
+        data_root=data_root,
+        bands={"S1RTC": ["VV", "VH"]},
+        db_scale_bands={"S1RTC": ["nonexistent_band"]},
+    )
+    with pytest.raises(ValueError):
+        ds[0]
+    gc.collect()
+
+
+def test_datamodule_passes_db_scale_bands_to_dataset(data_root):
+    """GELOSDataModule forwards db_scale_bands to the dataset in setup()."""
+    db_scale_bands = {"S1RTC": ["VV", "VH"]}
+    dm = GELOSDataModule(
+        data_root=data_root,
+        batch_size=1,
+        num_workers=0,
+        dataset_class=ExampleGELOSDataSet,
+        bands={"S1RTC": ["VV", "VH"]},
+        db_scale_bands=db_scale_bands,
+    )
+    dm.setup(stage="predict")
+    assert dm.dataset.db_scale_bands == db_scale_bands
     gc.collect()
 
 

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,0 +1,100 @@
+import pytest
+
+from gelos.normalization import (
+    MODEL_NORMALIZATION,
+    inject_model_normalization,
+    resolve_model_normalization,
+)
+
+PRITHVI_BANDS = ["BLUE", "GREEN", "RED", "NIR_NARROW", "SWIR_1", "SWIR_2"]
+TERRAMIND_S2_BANDS = [
+    "COASTAL_AEROSOL",
+    "BLUE",
+    "GREEN",
+    "RED",
+    "RED_EDGE_1",
+    "RED_EDGE_2",
+    "RED_EDGE_3",
+    "NIR_BROAD",
+    "NIR_NARROW",
+    "WATER_VAPOR",
+    "SWIR_1",
+    "SWIR_2",
+]
+
+
+def test_prithvi_resolves_v2_stats():
+    resolved = resolve_model_normalization("prithvi_eo_v2_300", {"S2L2A": PRITHVI_BANDS})
+    assert set(resolved) == {"means", "stds"}
+    assert resolved["means"]["S2L2A"]["BLUE"] == 1087.0
+    assert resolved["means"]["S2L2A"]["NIR_NARROW"] == 2734.0
+    assert resolved["stds"]["S2L2A"]["SWIR_2"] == 1049.0
+
+
+def test_prithvi_band_subset_and_order_respected():
+    resolved = resolve_model_normalization("prithvi_eo_v2_600", {"S2L2A": ["RED", "BLUE"]})
+    assert list(resolved["means"]["S2L2A"]) == ["RED", "BLUE"]
+    assert resolved["means"]["S2L2A"] == {"RED": 1433.0, "BLUE": 1087.0}
+
+
+def test_prithvi_unknown_band_raises():
+    with pytest.raises(ValueError, match="COASTAL_AEROSOL"):
+        resolve_model_normalization("prithvi_eo_v2_300", {"S2L2A": ["BLUE", "COASTAL_AEROSOL"]})
+
+
+def test_prithvi_unknown_modality_raises():
+    with pytest.raises(ValueError, match="S1RTC"):
+        resolve_model_normalization(
+            "prithvi_eo_v2_300", {"S2L2A": PRITHVI_BANDS, "S1RTC": ["VV", "VH"]}
+        )
+
+
+def test_terramind_resolves_multimodal_stats_and_db_scale():
+    resolved = resolve_model_normalization(
+        "terramind_v1_base",
+        {"S2L2A": TERRAMIND_S2_BANDS, "S1RTC": ["VV", "VH"], "DEM": ["DEM"]},
+    )
+    assert resolved["means"]["S1RTC"] == {"VV": -10.93, "VH": -17.329}
+    assert resolved["stds"]["S1RTC"] == {"VV": 4.391, "VH": 4.459}
+    assert resolved["means"]["S2L2A"]["COASTAL_AEROSOL"] == 1390.458
+    assert resolved["stds"]["S2L2A"]["SWIR_2"] == 1334.311
+    assert resolved["means"]["DEM"] == {"DEM": 670.665}
+    # dB conversion applies to S1 only
+    assert resolved["db_scale_bands"] == {"S1RTC": ["VV", "VH"]}
+
+
+def test_terramind_s2_only_has_no_db_scale():
+    resolved = resolve_model_normalization("terramind_v1_large", {"S2L2A": TERRAMIND_S2_BANDS})
+    assert "db_scale_bands" not in resolved
+
+
+def test_olmoearth_disables_datamodule_normalization():
+    resolved = resolve_model_normalization("olmoearth_v1_base_s1s2", {"S2L2A": ["BLUE"]})
+    assert resolved == {"normalize": False}
+
+
+def test_unknown_model_returns_none():
+    assert resolve_model_normalization("some_future_model", {"S2L2A": ["BLUE"]}) is None
+
+
+def test_inject_fills_missing_keys_only():
+    data_init = {
+        "bands": {"S1RTC": ["VV", "VH"]},
+        "means": {"S1RTC": {"VV": -1.0, "VH": -2.0}},
+    }
+    injected = inject_model_normalization(data_init, "terramind_v1_base")
+    assert sorted(injected) == ["db_scale_bands", "stds"]
+    # explicit config means untouched
+    assert data_init["means"] == {"S1RTC": {"VV": -1.0, "VH": -2.0}}
+    assert data_init["stds"]["S1RTC"] == {"VV": 4.391, "VH": 4.459}
+
+
+def test_inject_unknown_model_or_missing_bands_is_noop():
+    data_init = {"bands": {"S2L2A": ["BLUE"]}}
+    assert inject_model_normalization(data_init, "some_future_model") == []
+    assert set(data_init) == {"bands"}
+    assert inject_model_normalization({}, "prithvi_eo_v2_300") == []
+
+
+def test_registry_covers_expected_models():
+    assert set(MODEL_NORMALIZATION) == {"prithvi_eo_v2", "terramind_v1", "olmoearth_v1"}

--- a/tests/test_olmoearth_backbone.py
+++ b/tests/test_olmoearth_backbone.py
@@ -377,12 +377,144 @@ def test_s1_band_reorder_index_missing_band_raises():
         build_s1_band_reorder_index(["VV"])
 
 
+# ---------------------------------------------------------------------------
+# Pretraining normalization helper tests — pure math, no model dependency.
+# Expected values are hand-computed as (x - (mean - 2σ)) / (4σ) using the
+# constants from olmoearth_pretrain/data/norm_configs/computed.json.
+# ---------------------------------------------------------------------------
+
+# computed.json sentinel1 stats (dB scale).
+_VV_MEAN, _VV_STD = -11.648990747328444, 10.840350299936597
+_VH_MEAN, _VH_STD = -17.745436133270044, 10.216274681392647
+# computed.json sentinel2_l2a stats for B02 (BLUE) and B08 (NIR_BROAD).
+_B02_MEAN, _B02_STD = 1188.9412572078477, 1859.1923971769581
+_B08_MEAN, _B08_STD = 2755.481305028308, 1612.2565699990187
+
+
+def _expected_minmax(x: float, mean: float, std: float) -> float:
+    return (x - (mean - 2 * std)) / (4 * std)
+
+
+def test_convert_to_db_matches_10_log10():
+    from gelos.backbones.olmoearth_backbone import convert_to_db
+
+    x = torch.tensor([1.0, 0.1, 0.01])
+    torch.testing.assert_close(convert_to_db(x), torch.tensor([0.0, -10.0, -20.0]))
+
+
+def test_convert_to_db_clips_at_1e_minus_10():
+    from gelos.backbones.olmoearth_backbone import convert_to_db
+
+    # Zero (and negative) linear power is clipped to 1e-10 -> -100 dB, not -inf.
+    x = torch.tensor([0.0, -5.0, 1e-12])
+    torch.testing.assert_close(convert_to_db(x), torch.tensor([-100.0, -100.0, -100.0]))
+
+
+def test_s1_normalization_matches_hand_computed():
+    from gelos.backbones.olmoearth_backbone import (
+        convert_to_db,
+        minmax_normalize,
+        resolve_s1_band_stats,
+    )
+
+    means, stds = resolve_s1_band_stats(["VV", "VH"])
+    assert means == [_VV_MEAN, _VH_MEAN]
+    assert stds == [_VV_STD, _VH_STD]
+
+    # Raw linear power (VV, VH), last axis = bands.
+    x = torch.tensor([[0.1, 0.01]], dtype=torch.float64)  # -> -10 dB, -20 dB
+    out = minmax_normalize(convert_to_db(x), means, stds)
+    expected = torch.tensor(
+        [
+            [
+                _expected_minmax(-10.0, _VV_MEAN, _VV_STD),
+                _expected_minmax(-20.0, _VH_MEAN, _VH_STD),
+            ]
+        ],
+        dtype=torch.float64,
+    )
+    torch.testing.assert_close(out, expected)
+
+
+def test_s2_normalization_matches_hand_computed():
+    from gelos.backbones.olmoearth_backbone import minmax_normalize, resolve_s2_band_stats
+
+    means, stds = resolve_s2_band_stats(["BLUE", "NIR_BROAD"])
+    assert means == [_B02_MEAN, _B08_MEAN]
+    assert stds == [_B02_STD, _B08_STD]
+
+    # Raw DN values, no log for S2.
+    x = torch.tensor([[1500.0, 3000.0]], dtype=torch.float64)
+    out = minmax_normalize(x, means, stds)
+    expected = torch.tensor(
+        [
+            [
+                _expected_minmax(1500.0, _B02_MEAN, _B02_STD),
+                _expected_minmax(3000.0, _B08_MEAN, _B08_STD),
+            ]
+        ],
+        dtype=torch.float64,
+    )
+    torch.testing.assert_close(out, expected)
+
+
+def test_s2_normalization_band_mean_maps_to_half():
+    # By construction, x == mean must normalize to exactly 0.5.
+    from gelos.backbones.olmoearth_backbone import minmax_normalize, resolve_s2_band_stats
+
+    means, stds = resolve_s2_band_stats(OLMOEARTH_S2_BAND_ORDER)
+    x = torch.tensor(means, dtype=torch.float64)
+    out = minmax_normalize(x, means, stds)
+    torch.testing.assert_close(out, torch.full_like(out, 0.5))
+
+
+def test_resolve_s2_band_stats_full_order_covers_all_12_bands():
+    from gelos.backbones.olmoearth_backbone import (
+        GELOS_TO_OLMOEARTH_S2_KEY,
+        OLMOEARTH_COMPUTED_STATS,
+        resolve_s2_band_stats,
+    )
+
+    means, stds = resolve_s2_band_stats(OLMOEARTH_S2_BAND_ORDER)
+    s2_stats = OLMOEARTH_COMPUTED_STATS["sentinel2_l2a"]
+    expected_keys = [GELOS_TO_OLMOEARTH_S2_KEY[b] for b in OLMOEARTH_S2_BAND_ORDER]
+    assert means == [s2_stats[k]["mean"] for k in expected_keys]
+    assert stds == [s2_stats[k]["std"] for k in expected_keys]
+
+
+def test_resolve_s2_band_stats_unknown_band_raises():
+    from gelos.backbones.olmoearth_backbone import resolve_s2_band_stats
+
+    with pytest.raises(ValueError, match="NOT_A_BAND"):
+        resolve_s2_band_stats(["BLUE", "NOT_A_BAND"])
+
+
+def test_resolve_s1_band_stats_unknown_band_raises():
+    from gelos.backbones.olmoearth_backbone import resolve_s1_band_stats
+
+    with pytest.raises(ValueError, match="HH"):
+        resolve_s1_band_stats(["HH"])
+
+
+def test_minmax_normalize_broadcasts_over_leading_dims():
+    # Same per-band math must apply at every (B, H, W, T) position.
+    from gelos.backbones.olmoearth_backbone import minmax_normalize
+
+    means, stds = [10.0, 20.0], [2.0, 4.0]
+    x = torch.full((2, 3, 3, 4, 2), 10.0)
+    x[..., 1] = 20.0  # each band sits exactly at its mean
+    out = minmax_normalize(x, means, stds)
+    torch.testing.assert_close(out, torch.full_like(out, 0.5))
+
+
 def test_example_s1s2_fixture_yaml_valid():
     import yaml
     from pathlib import Path
 
     path = Path(__file__).parent / "fixtures" / "example_olmoearth_s1s2_config.yaml"
     config = yaml.safe_load(path.read_text())
+    # The backbone normalizes internally; the datamodule must not double-normalize.
+    assert config["data"]["init_args"]["normalize"] is False
     bands = config["data"]["init_args"]["bands"]
     assert "S1RTC" in bands
     assert set(bands["S1RTC"]) == {"VV", "VH"}


### PR DESCRIPTION
This PR addresses three problems in the existing pipeline. First, models which rely on dB scaling for sentinel-1-rtc were being passed linear-power values directly from Planetary Computer. Now, models normalize S1 according to how they were pretrained, which differs for Terramind and OlmoEarth. Second, a case mismatch between gelos and gelos-lc ('means' vs 'MEANS') was causing no normalization to be applied. A clear warning is now raised when no normalization is applied when running embedding generation, as this means something is wrong. Third, default behavior is now to get normalization statistics directly from the model, as is the convention for calculating embeddings from frozen backbones, matching conventions set in the OlmoEarth implementation. Users may still set their own mean and standard deviation statistics within the dataloader and direct gelos to normalize using these, but default behavior is to use the statistics used during pretraining.