### PR TITLE
Add OlmoEarth v1.2 to GELOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ gelos = {git = "https://github.com/ClarkCGA/gelos.git", tag = "v1.0.0"}
 
 ## [Unreleased]
 
+- **OlmoEarth v1.2 backbones.** New terratorch factory functions
+  `olmoearth_v1_2_{nano,tiny,small,base}` (Sentinel-2 only) and `..._s1s2` (S2+S1),
+  registered in `BACKBONE_REGISTRY`, with hidden dims 128/192/384/768. New shipped
+  configs `configs/olmoearth_v1_2_*.yaml`. v1.2 adds a `small` (D=384) size and drops
+  `large`; it reuses v1's band order and pretraining normalization statistics unchanged,
+  so `gelos/normalization.py` (prefix-matched to `olmoearth_v1`) already covers the new
+  names. Bumps `olmoearth-pretrain>=0.1.1` (the first release exposing the v1.2 `ModelID`
+  entries).
 - **Analysis completion markers.** `run_analysis` now writes a `.analysis_complete` marker
   (mirroring generation's `.embeddings_complete`) and skips fully-completed configs on
   re-runs. Model runs (`knn`/`linear_probe`/`random_forest`) now also skip individually

--- a/configs/olmoearth_v1_2_base.yaml
+++ b/configs/olmoearth_v1_2_base.yaml
@@ -1,0 +1,110 @@
+experiment_name: "OlmoEarth V1.2 Base"
+data_version: "v0.50.1"
+chip_tracker: "gelos_chip_tracker.geojson"
+chip_id_column: "id"
+
+seed_everything: 0
+trainer:
+  accelerator: auto
+  strategy: auto
+  devices: auto
+  num_nodes: 1
+  callbacks: []
+  max_epochs: 0
+
+data:
+  class_path: gelos.gelosdatamodule.GELOSDataModule
+  init_args:
+    dataset_class: gelos.gelosdataset.GELOSDataSet
+    batch_size: 8
+    num_workers: 4
+    # OlmoEarth is Sentinel-2 L2A only here. It requires the full 12-band S2L2A
+    # set; the production GELOS-LC dataset must supply all of these (including
+    # WATER_VAPOR / B09, which ExampleGELOSDataSet does not define). Bands must
+    # be RAW digital numbers (0-10000) -- the backbone applies OlmoEarth's
+    # pretraining normalization internally, hence normalize: false below.
+    normalize: false
+    bands:
+      S2L2A:
+        - COASTAL_AEROSOL   # B01
+        - BLUE              # B02
+        - GREEN             # B03
+        - RED               # B04
+        - RED_EDGE_1        # B05
+        - RED_EDGE_2        # B06
+        - RED_EDGE_3        # B07
+        - NIR_BROAD         # B08
+        - NIR_NARROW        # B8A
+        - WATER_VAPOR       # B09
+        - SWIR_1            # B11
+        - SWIR_2            # B12
+    transform:
+      - class_path: terratorch.datasets.transforms.FlattenTemporalIntoChannels
+      - class_path: albumentations.augmentations.geometric.resize.Resize
+        init_args:
+          height: 96
+          width: 96
+          interpolation: 0 # Nearest Neighbor
+      - class_path: albumentations.pytorch.transforms.ToTensorV2
+      - class_path: terratorch.datasets.transforms.UnflattenTemporalFromChannels
+        init_args:
+          n_timesteps: 4
+model:
+  class_path: terratorch.tasks.EmbeddingGenerationTask
+  title: OlmoEarth V1.2 Base
+  init_args:
+    model: olmoearth_v1_2_base  # registered via gelos.backbones.olmoearth_backbone
+    model_args:
+      model_id: allenai/OlmoEarth-v1_2-Base
+      pretrained: True
+      patch_size: 4
+      # Bands in the order the incoming tensor presents them; the wrapper reorders
+      # to OlmoEarth's internal 12-band order. Must match data.bands.S2L2A above.
+      bands:
+        - COASTAL_AEROSOL
+        - BLUE
+        - GREEN
+        - RED
+        - RED_EDGE_1
+        - RED_EDGE_2
+        - RED_EDGE_3
+        - NIR_BROAD
+        - NIR_NARROW
+        - WATER_VAPOR
+        - SWIR_1
+        - SWIR_2
+    output_format: parquet
+    embed_file_key: filename
+    layers: [-1] # Model layers to extract embeddings from, -1 means the last layer
+    embedding_pooling: null
+    has_cls: False
+    temporal_cfg:
+      # temporal_wrapper MUST be False for OlmoEarth. TemporalWrapper.forward
+      # reshapes (B,C,T,H,W) -> (B*T,C,H,W) (4D) before calling the backbone, but
+      # OlmoEarthBackbone.forward_features requires a 5D (B,C,T,H,W) tensor and
+      # raises on 4D input. OlmoEarth runs on the un-wrapped 5D path, where the
+      # per-timestep (B,T,3) timestamps also align with the temporal axis.
+      temporal_wrapper: False
+      temporal_pooling: keep
+
+# each strategy defines extraction args (slice_args) and optional analysis steps
+embedding_extraction_strategies:
+  all_embeddings:
+    title: "All Embeddings"
+    slice_args:
+      - start: 0
+        stop: null
+        step:
+    transforms:
+      - type: pca
+        params:
+          n_components: 2
+
+style:
+  category_column: "lulc"
+  colors:
+    "1": "#419bdf"    # Water
+    "2": "#397d49"    # Trees
+  labels:
+    "1": "Water"
+    "2": "Trees"

--- a/configs/olmoearth_v1_2_base_s1s2.yaml
+++ b/configs/olmoearth_v1_2_base_s1s2.yaml
@@ -1,0 +1,120 @@
+experiment_name: "OlmoEarth V1.2 Base - S2+S1"
+data_version: "v0.50.1"
+chip_tracker: "gelos_chip_tracker.geojson"
+chip_id_column: "id"
+
+seed_everything: 0
+trainer:
+  accelerator: auto
+  strategy: auto
+  devices: auto
+  num_nodes: 1
+  callbacks: []
+  max_epochs: 0
+
+data:
+  class_path: gelos.gelosdatamodule.GELOSDataModule
+  init_args:
+    dataset_class: gelos.gelosdataset.GELOSDataSet
+    batch_size: 8
+    num_workers: 4
+    # OlmoEarth S2+S1 mode. S2 requires the full 12-band S2L2A set (including
+    # WATER_VAPOR / B09) as RAW digital numbers (0-10000). S1 requires VV and VH
+    # as RAW LINEAR POWER gamma0 (e.g. Planetary Computer sentinel-1-rtc) -- the
+    # backbone converts S1 to dB and applies OlmoEarth's pretraining
+    # normalization to both modalities internally, hence normalize: false below.
+    # Do NOT set db_scale_bands for S1 here, or values get double-transformed.
+    normalize: false
+    bands:
+      S2L2A:
+        - COASTAL_AEROSOL   # B01
+        - BLUE              # B02
+        - GREEN             # B03
+        - RED               # B04
+        - RED_EDGE_1        # B05
+        - RED_EDGE_2        # B06
+        - RED_EDGE_3        # B07
+        - NIR_BROAD         # B08
+        - NIR_NARROW        # B8A
+        - WATER_VAPOR       # B09
+        - SWIR_1            # B11
+        - SWIR_2            # B12
+      S1RTC:
+        - VV
+        - VH
+    transform:
+      - class_path: terratorch.datasets.transforms.FlattenTemporalIntoChannels
+      - class_path: albumentations.augmentations.geometric.resize.Resize
+        init_args:
+          height: 96
+          width: 96
+          interpolation: 0 # Nearest Neighbor
+      - class_path: albumentations.pytorch.transforms.ToTensorV2
+      - class_path: terratorch.datasets.transforms.UnflattenTemporalFromChannels
+        init_args:
+          n_timesteps: 4
+model:
+  class_path: terratorch.tasks.EmbeddingGenerationTask
+  title: OlmoEarth V1.2 Base S2+S1
+  init_args:
+    model: olmoearth_v1_2_base_s1s2  # registered via gelos.backbones.olmoearth_backbone
+    model_args:
+      model_id: allenai/OlmoEarth-v1_2-Base
+      pretrained: True
+      patch_size: 4
+      # Bands in the order the incoming tensor presents them; the wrapper reorders
+      # to OlmoEarth's internal 12-band order. Must match data.bands.S2L2A above.
+      bands:
+        - COASTAL_AEROSOL
+        - BLUE
+        - GREEN
+        - RED
+        - RED_EDGE_1
+        - RED_EDGE_2
+        - RED_EDGE_3
+        - NIR_BROAD
+        - NIR_NARROW
+        - WATER_VAPOR
+        - SWIR_1
+        - SWIR_2
+      # S1 bands in the order the incoming tensor presents them. Must match
+      # data.bands.S1RTC above. S1 input must be RAW linear power; the wrapper
+      # converts to dB and normalizes internally (apply_pretraining_normalization).
+      bands_s1:
+        - VV
+        - VH
+    output_format: parquet
+    embed_file_key: filename
+    layers: [-1] # Model layers to extract embeddings from, -1 means the last layer
+    embedding_pooling: null
+    has_cls: False
+    temporal_cfg:
+      # temporal_wrapper MUST be False for OlmoEarth. TemporalWrapper.forward
+      # reshapes (B,C,T,H,W) -> (B*T,C,H,W) (4D) before calling the backbone, but
+      # OlmoEarthBackbone.forward_features requires a 5D (B,C,T,H,W) tensor and
+      # raises on 4D input. OlmoEarth runs on the un-wrapped 5D path, where the
+      # per-timestep (B,T,3) timestamps also align with the temporal axis.
+      temporal_wrapper: False
+      temporal_pooling: keep
+
+# each strategy defines extraction args (slice_args) and optional analysis steps
+embedding_extraction_strategies:
+  all_embeddings:
+    title: "All Embeddings"
+    slice_args:
+      - start: 0
+        stop: null
+        step:
+    transforms:
+      - type: pca
+        params:
+          n_components: 2
+
+style:
+  category_column: "lulc"
+  colors:
+    "1": "#419bdf"    # Water
+    "2": "#397d49"    # Trees
+  labels:
+    "1": "Water"
+    "2": "Trees"

--- a/configs/olmoearth_v1_2_nano.yaml
+++ b/configs/olmoearth_v1_2_nano.yaml
@@ -1,0 +1,110 @@
+experiment_name: "OlmoEarth V1.2 Nano"
+data_version: "v0.50.1"
+chip_tracker: "gelos_chip_tracker.geojson"
+chip_id_column: "id"
+
+seed_everything: 0
+trainer:
+  accelerator: auto
+  strategy: auto
+  devices: auto
+  num_nodes: 1
+  callbacks: []
+  max_epochs: 0
+
+data:
+  class_path: gelos.gelosdatamodule.GELOSDataModule
+  init_args:
+    dataset_class: gelos.gelosdataset.GELOSDataSet
+    batch_size: 8
+    num_workers: 4
+    # OlmoEarth is Sentinel-2 L2A only here. It requires the full 12-band S2L2A
+    # set; the production GELOS-LC dataset must supply all of these (including
+    # WATER_VAPOR / B09, which ExampleGELOSDataSet does not define). Bands must
+    # be RAW digital numbers (0-10000) -- the backbone applies OlmoEarth's
+    # pretraining normalization internally, hence normalize: false below.
+    normalize: false
+    bands:
+      S2L2A:
+        - COASTAL_AEROSOL   # B01
+        - BLUE              # B02
+        - GREEN             # B03
+        - RED               # B04
+        - RED_EDGE_1        # B05
+        - RED_EDGE_2        # B06
+        - RED_EDGE_3        # B07
+        - NIR_BROAD         # B08
+        - NIR_NARROW        # B8A
+        - WATER_VAPOR       # B09
+        - SWIR_1            # B11
+        - SWIR_2            # B12
+    transform:
+      - class_path: terratorch.datasets.transforms.FlattenTemporalIntoChannels
+      - class_path: albumentations.augmentations.geometric.resize.Resize
+        init_args:
+          height: 96
+          width: 96
+          interpolation: 0 # Nearest Neighbor
+      - class_path: albumentations.pytorch.transforms.ToTensorV2
+      - class_path: terratorch.datasets.transforms.UnflattenTemporalFromChannels
+        init_args:
+          n_timesteps: 4
+model:
+  class_path: terratorch.tasks.EmbeddingGenerationTask
+  title: OlmoEarth V1.2 Nano
+  init_args:
+    model: olmoearth_v1_2_nano  # registered via gelos.backbones.olmoearth_backbone
+    model_args:
+      model_id: allenai/OlmoEarth-v1_2-Nano
+      pretrained: True
+      patch_size: 4
+      # Bands in the order the incoming tensor presents them; the wrapper reorders
+      # to OlmoEarth's internal 12-band order. Must match data.bands.S2L2A above.
+      bands:
+        - COASTAL_AEROSOL
+        - BLUE
+        - GREEN
+        - RED
+        - RED_EDGE_1
+        - RED_EDGE_2
+        - RED_EDGE_3
+        - NIR_BROAD
+        - NIR_NARROW
+        - WATER_VAPOR
+        - SWIR_1
+        - SWIR_2
+    output_format: parquet
+    embed_file_key: filename
+    layers: [-1] # Model layers to extract embeddings from, -1 means the last layer
+    embedding_pooling: null
+    has_cls: False
+    temporal_cfg:
+      # temporal_wrapper MUST be False for OlmoEarth. TemporalWrapper.forward
+      # reshapes (B,C,T,H,W) -> (B*T,C,H,W) (4D) before calling the backbone, but
+      # OlmoEarthBackbone.forward_features requires a 5D (B,C,T,H,W) tensor and
+      # raises on 4D input. OlmoEarth runs on the un-wrapped 5D path, where the
+      # per-timestep (B,T,3) timestamps also align with the temporal axis.
+      temporal_wrapper: False
+      temporal_pooling: keep
+
+# each strategy defines extraction args (slice_args) and optional analysis steps
+embedding_extraction_strategies:
+  all_embeddings:
+    title: "All Embeddings"
+    slice_args:
+      - start: 0
+        stop: null
+        step:
+    transforms:
+      - type: pca
+        params:
+          n_components: 2
+
+style:
+  category_column: "lulc"
+  colors:
+    "1": "#419bdf"    # Water
+    "2": "#397d49"    # Trees
+  labels:
+    "1": "Water"
+    "2": "Trees"

--- a/configs/olmoearth_v1_2_nano_s1s2.yaml
+++ b/configs/olmoearth_v1_2_nano_s1s2.yaml
@@ -1,0 +1,120 @@
+experiment_name: "OlmoEarth V1.2 Nano - S2+S1"
+data_version: "v0.50.1"
+chip_tracker: "gelos_chip_tracker.geojson"
+chip_id_column: "id"
+
+seed_everything: 0
+trainer:
+  accelerator: auto
+  strategy: auto
+  devices: auto
+  num_nodes: 1
+  callbacks: []
+  max_epochs: 0
+
+data:
+  class_path: gelos.gelosdatamodule.GELOSDataModule
+  init_args:
+    dataset_class: gelos.gelosdataset.GELOSDataSet
+    batch_size: 8
+    num_workers: 4
+    # OlmoEarth S2+S1 mode. S2 requires the full 12-band S2L2A set (including
+    # WATER_VAPOR / B09) as RAW digital numbers (0-10000). S1 requires VV and VH
+    # as RAW LINEAR POWER gamma0 (e.g. Planetary Computer sentinel-1-rtc) -- the
+    # backbone converts S1 to dB and applies OlmoEarth's pretraining
+    # normalization to both modalities internally, hence normalize: false below.
+    # Do NOT set db_scale_bands for S1 here, or values get double-transformed.
+    normalize: false
+    bands:
+      S2L2A:
+        - COASTAL_AEROSOL   # B01
+        - BLUE              # B02
+        - GREEN             # B03
+        - RED               # B04
+        - RED_EDGE_1        # B05
+        - RED_EDGE_2        # B06
+        - RED_EDGE_3        # B07
+        - NIR_BROAD         # B08
+        - NIR_NARROW        # B8A
+        - WATER_VAPOR       # B09
+        - SWIR_1            # B11
+        - SWIR_2            # B12
+      S1RTC:
+        - VV
+        - VH
+    transform:
+      - class_path: terratorch.datasets.transforms.FlattenTemporalIntoChannels
+      - class_path: albumentations.augmentations.geometric.resize.Resize
+        init_args:
+          height: 96
+          width: 96
+          interpolation: 0 # Nearest Neighbor
+      - class_path: albumentations.pytorch.transforms.ToTensorV2
+      - class_path: terratorch.datasets.transforms.UnflattenTemporalFromChannels
+        init_args:
+          n_timesteps: 4
+model:
+  class_path: terratorch.tasks.EmbeddingGenerationTask
+  title: OlmoEarth V1.2 Nano S2+S1
+  init_args:
+    model: olmoearth_v1_2_nano_s1s2  # registered via gelos.backbones.olmoearth_backbone
+    model_args:
+      model_id: allenai/OlmoEarth-v1_2-Nano
+      pretrained: True
+      patch_size: 4
+      # Bands in the order the incoming tensor presents them; the wrapper reorders
+      # to OlmoEarth's internal 12-band order. Must match data.bands.S2L2A above.
+      bands:
+        - COASTAL_AEROSOL
+        - BLUE
+        - GREEN
+        - RED
+        - RED_EDGE_1
+        - RED_EDGE_2
+        - RED_EDGE_3
+        - NIR_BROAD
+        - NIR_NARROW
+        - WATER_VAPOR
+        - SWIR_1
+        - SWIR_2
+      # S1 bands in the order the incoming tensor presents them. Must match
+      # data.bands.S1RTC above. S1 input must be RAW linear power; the wrapper
+      # converts to dB and normalizes internally (apply_pretraining_normalization).
+      bands_s1:
+        - VV
+        - VH
+    output_format: parquet
+    embed_file_key: filename
+    layers: [-1] # Model layers to extract embeddings from, -1 means the last layer
+    embedding_pooling: null
+    has_cls: False
+    temporal_cfg:
+      # temporal_wrapper MUST be False for OlmoEarth. TemporalWrapper.forward
+      # reshapes (B,C,T,H,W) -> (B*T,C,H,W) (4D) before calling the backbone, but
+      # OlmoEarthBackbone.forward_features requires a 5D (B,C,T,H,W) tensor and
+      # raises on 4D input. OlmoEarth runs on the un-wrapped 5D path, where the
+      # per-timestep (B,T,3) timestamps also align with the temporal axis.
+      temporal_wrapper: False
+      temporal_pooling: keep
+
+# each strategy defines extraction args (slice_args) and optional analysis steps
+embedding_extraction_strategies:
+  all_embeddings:
+    title: "All Embeddings"
+    slice_args:
+      - start: 0
+        stop: null
+        step:
+    transforms:
+      - type: pca
+        params:
+          n_components: 2
+
+style:
+  category_column: "lulc"
+  colors:
+    "1": "#419bdf"    # Water
+    "2": "#397d49"    # Trees
+  labels:
+    "1": "Water"
+    "2": "Trees"

--- a/configs/olmoearth_v1_2_small.yaml
+++ b/configs/olmoearth_v1_2_small.yaml
@@ -1,0 +1,110 @@
+experiment_name: "OlmoEarth V1.2 Small"
+data_version: "v0.50.1"
+chip_tracker: "gelos_chip_tracker.geojson"
+chip_id_column: "id"
+
+seed_everything: 0
+trainer:
+  accelerator: auto
+  strategy: auto
+  devices: auto
+  num_nodes: 1
+  callbacks: []
+  max_epochs: 0
+
+data:
+  class_path: gelos.gelosdatamodule.GELOSDataModule
+  init_args:
+    dataset_class: gelos.gelosdataset.GELOSDataSet
+    batch_size: 8
+    num_workers: 4
+    # OlmoEarth is Sentinel-2 L2A only here. It requires the full 12-band S2L2A
+    # set; the production GELOS-LC dataset must supply all of these (including
+    # WATER_VAPOR / B09, which ExampleGELOSDataSet does not define). Bands must
+    # be RAW digital numbers (0-10000) -- the backbone applies OlmoEarth's
+    # pretraining normalization internally, hence normalize: false below.
+    normalize: false
+    bands:
+      S2L2A:
+        - COASTAL_AEROSOL   # B01
+        - BLUE              # B02
+        - GREEN             # B03
+        - RED               # B04
+        - RED_EDGE_1        # B05
+        - RED_EDGE_2        # B06
+        - RED_EDGE_3        # B07
+        - NIR_BROAD         # B08
+        - NIR_NARROW        # B8A
+        - WATER_VAPOR       # B09
+        - SWIR_1            # B11
+        - SWIR_2            # B12
+    transform:
+      - class_path: terratorch.datasets.transforms.FlattenTemporalIntoChannels
+      - class_path: albumentations.augmentations.geometric.resize.Resize
+        init_args:
+          height: 96
+          width: 96
+          interpolation: 0 # Nearest Neighbor
+      - class_path: albumentations.pytorch.transforms.ToTensorV2
+      - class_path: terratorch.datasets.transforms.UnflattenTemporalFromChannels
+        init_args:
+          n_timesteps: 4
+model:
+  class_path: terratorch.tasks.EmbeddingGenerationTask
+  title: OlmoEarth V1.2 Small
+  init_args:
+    model: olmoearth_v1_2_small  # registered via gelos.backbones.olmoearth_backbone
+    model_args:
+      model_id: allenai/OlmoEarth-v1_2-Small
+      pretrained: True
+      patch_size: 4
+      # Bands in the order the incoming tensor presents them; the wrapper reorders
+      # to OlmoEarth's internal 12-band order. Must match data.bands.S2L2A above.
+      bands:
+        - COASTAL_AEROSOL
+        - BLUE
+        - GREEN
+        - RED
+        - RED_EDGE_1
+        - RED_EDGE_2
+        - RED_EDGE_3
+        - NIR_BROAD
+        - NIR_NARROW
+        - WATER_VAPOR
+        - SWIR_1
+        - SWIR_2
+    output_format: parquet
+    embed_file_key: filename
+    layers: [-1] # Model layers to extract embeddings from, -1 means the last layer
+    embedding_pooling: null
+    has_cls: False
+    temporal_cfg:
+      # temporal_wrapper MUST be False for OlmoEarth. TemporalWrapper.forward
+      # reshapes (B,C,T,H,W) -> (B*T,C,H,W) (4D) before calling the backbone, but
+      # OlmoEarthBackbone.forward_features requires a 5D (B,C,T,H,W) tensor and
+      # raises on 4D input. OlmoEarth runs on the un-wrapped 5D path, where the
+      # per-timestep (B,T,3) timestamps also align with the temporal axis.
+      temporal_wrapper: False
+      temporal_pooling: keep
+
+# each strategy defines extraction args (slice_args) and optional analysis steps
+embedding_extraction_strategies:
+  all_embeddings:
+    title: "All Embeddings"
+    slice_args:
+      - start: 0
+        stop: null
+        step:
+    transforms:
+      - type: pca
+        params:
+          n_components: 2
+
+style:
+  category_column: "lulc"
+  colors:
+    "1": "#419bdf"    # Water
+    "2": "#397d49"    # Trees
+  labels:
+    "1": "Water"
+    "2": "Trees"

--- a/configs/olmoearth_v1_2_small_s1s2.yaml
+++ b/configs/olmoearth_v1_2_small_s1s2.yaml
@@ -1,0 +1,120 @@
+experiment_name: "OlmoEarth V1.2 Small - S2+S1"
+data_version: "v0.50.1"
+chip_tracker: "gelos_chip_tracker.geojson"
+chip_id_column: "id"
+
+seed_everything: 0
+trainer:
+  accelerator: auto
+  strategy: auto
+  devices: auto
+  num_nodes: 1
+  callbacks: []
+  max_epochs: 0
+
+data:
+  class_path: gelos.gelosdatamodule.GELOSDataModule
+  init_args:
+    dataset_class: gelos.gelosdataset.GELOSDataSet
+    batch_size: 8
+    num_workers: 4
+    # OlmoEarth S2+S1 mode. S2 requires the full 12-band S2L2A set (including
+    # WATER_VAPOR / B09) as RAW digital numbers (0-10000). S1 requires VV and VH
+    # as RAW LINEAR POWER gamma0 (e.g. Planetary Computer sentinel-1-rtc) -- the
+    # backbone converts S1 to dB and applies OlmoEarth's pretraining
+    # normalization to both modalities internally, hence normalize: false below.
+    # Do NOT set db_scale_bands for S1 here, or values get double-transformed.
+    normalize: false
+    bands:
+      S2L2A:
+        - COASTAL_AEROSOL   # B01
+        - BLUE              # B02
+        - GREEN             # B03
+        - RED               # B04
+        - RED_EDGE_1        # B05
+        - RED_EDGE_2        # B06
+        - RED_EDGE_3        # B07
+        - NIR_BROAD         # B08
+        - NIR_NARROW        # B8A
+        - WATER_VAPOR       # B09
+        - SWIR_1            # B11
+        - SWIR_2            # B12
+      S1RTC:
+        - VV
+        - VH
+    transform:
+      - class_path: terratorch.datasets.transforms.FlattenTemporalIntoChannels
+      - class_path: albumentations.augmentations.geometric.resize.Resize
+        init_args:
+          height: 96
+          width: 96
+          interpolation: 0 # Nearest Neighbor
+      - class_path: albumentations.pytorch.transforms.ToTensorV2
+      - class_path: terratorch.datasets.transforms.UnflattenTemporalFromChannels
+        init_args:
+          n_timesteps: 4
+model:
+  class_path: terratorch.tasks.EmbeddingGenerationTask
+  title: OlmoEarth V1.2 Small S2+S1
+  init_args:
+    model: olmoearth_v1_2_small_s1s2  # registered via gelos.backbones.olmoearth_backbone
+    model_args:
+      model_id: allenai/OlmoEarth-v1_2-Small
+      pretrained: True
+      patch_size: 4
+      # Bands in the order the incoming tensor presents them; the wrapper reorders
+      # to OlmoEarth's internal 12-band order. Must match data.bands.S2L2A above.
+      bands:
+        - COASTAL_AEROSOL
+        - BLUE
+        - GREEN
+        - RED
+        - RED_EDGE_1
+        - RED_EDGE_2
+        - RED_EDGE_3
+        - NIR_BROAD
+        - NIR_NARROW
+        - WATER_VAPOR
+        - SWIR_1
+        - SWIR_2
+      # S1 bands in the order the incoming tensor presents them. Must match
+      # data.bands.S1RTC above. S1 input must be RAW linear power; the wrapper
+      # converts to dB and normalizes internally (apply_pretraining_normalization).
+      bands_s1:
+        - VV
+        - VH
+    output_format: parquet
+    embed_file_key: filename
+    layers: [-1] # Model layers to extract embeddings from, -1 means the last layer
+    embedding_pooling: null
+    has_cls: False
+    temporal_cfg:
+      # temporal_wrapper MUST be False for OlmoEarth. TemporalWrapper.forward
+      # reshapes (B,C,T,H,W) -> (B*T,C,H,W) (4D) before calling the backbone, but
+      # OlmoEarthBackbone.forward_features requires a 5D (B,C,T,H,W) tensor and
+      # raises on 4D input. OlmoEarth runs on the un-wrapped 5D path, where the
+      # per-timestep (B,T,3) timestamps also align with the temporal axis.
+      temporal_wrapper: False
+      temporal_pooling: keep
+
+# each strategy defines extraction args (slice_args) and optional analysis steps
+embedding_extraction_strategies:
+  all_embeddings:
+    title: "All Embeddings"
+    slice_args:
+      - start: 0
+        stop: null
+        step:
+    transforms:
+      - type: pca
+        params:
+          n_components: 2
+
+style:
+  category_column: "lulc"
+  colors:
+    "1": "#419bdf"    # Water
+    "2": "#397d49"    # Trees
+  labels:
+    "1": "Water"
+    "2": "Trees"

--- a/configs/olmoearth_v1_2_tiny.yaml
+++ b/configs/olmoearth_v1_2_tiny.yaml
@@ -1,0 +1,110 @@
+experiment_name: "OlmoEarth V1.2 Tiny"
+data_version: "v0.50.1"
+chip_tracker: "gelos_chip_tracker.geojson"
+chip_id_column: "id"
+
+seed_everything: 0
+trainer:
+  accelerator: auto
+  strategy: auto
+  devices: auto
+  num_nodes: 1
+  callbacks: []
+  max_epochs: 0
+
+data:
+  class_path: gelos.gelosdatamodule.GELOSDataModule
+  init_args:
+    dataset_class: gelos.gelosdataset.GELOSDataSet
+    batch_size: 8
+    num_workers: 4
+    # OlmoEarth is Sentinel-2 L2A only here. It requires the full 12-band S2L2A
+    # set; the production GELOS-LC dataset must supply all of these (including
+    # WATER_VAPOR / B09, which ExampleGELOSDataSet does not define). Bands must
+    # be RAW digital numbers (0-10000) -- the backbone applies OlmoEarth's
+    # pretraining normalization internally, hence normalize: false below.
+    normalize: false
+    bands:
+      S2L2A:
+        - COASTAL_AEROSOL   # B01
+        - BLUE              # B02
+        - GREEN             # B03
+        - RED               # B04
+        - RED_EDGE_1        # B05
+        - RED_EDGE_2        # B06
+        - RED_EDGE_3        # B07
+        - NIR_BROAD         # B08
+        - NIR_NARROW        # B8A
+        - WATER_VAPOR       # B09
+        - SWIR_1            # B11
+        - SWIR_2            # B12
+    transform:
+      - class_path: terratorch.datasets.transforms.FlattenTemporalIntoChannels
+      - class_path: albumentations.augmentations.geometric.resize.Resize
+        init_args:
+          height: 96
+          width: 96
+          interpolation: 0 # Nearest Neighbor
+      - class_path: albumentations.pytorch.transforms.ToTensorV2
+      - class_path: terratorch.datasets.transforms.UnflattenTemporalFromChannels
+        init_args:
+          n_timesteps: 4
+model:
+  class_path: terratorch.tasks.EmbeddingGenerationTask
+  title: OlmoEarth V1.2 Tiny
+  init_args:
+    model: olmoearth_v1_2_tiny  # registered via gelos.backbones.olmoearth_backbone
+    model_args:
+      model_id: allenai/OlmoEarth-v1_2-Tiny
+      pretrained: True
+      patch_size: 4
+      # Bands in the order the incoming tensor presents them; the wrapper reorders
+      # to OlmoEarth's internal 12-band order. Must match data.bands.S2L2A above.
+      bands:
+        - COASTAL_AEROSOL
+        - BLUE
+        - GREEN
+        - RED
+        - RED_EDGE_1
+        - RED_EDGE_2
+        - RED_EDGE_3
+        - NIR_BROAD
+        - NIR_NARROW
+        - WATER_VAPOR
+        - SWIR_1
+        - SWIR_2
+    output_format: parquet
+    embed_file_key: filename
+    layers: [-1] # Model layers to extract embeddings from, -1 means the last layer
+    embedding_pooling: null
+    has_cls: False
+    temporal_cfg:
+      # temporal_wrapper MUST be False for OlmoEarth. TemporalWrapper.forward
+      # reshapes (B,C,T,H,W) -> (B*T,C,H,W) (4D) before calling the backbone, but
+      # OlmoEarthBackbone.forward_features requires a 5D (B,C,T,H,W) tensor and
+      # raises on 4D input. OlmoEarth runs on the un-wrapped 5D path, where the
+      # per-timestep (B,T,3) timestamps also align with the temporal axis.
+      temporal_wrapper: False
+      temporal_pooling: keep
+
+# each strategy defines extraction args (slice_args) and optional analysis steps
+embedding_extraction_strategies:
+  all_embeddings:
+    title: "All Embeddings"
+    slice_args:
+      - start: 0
+        stop: null
+        step:
+    transforms:
+      - type: pca
+        params:
+          n_components: 2
+
+style:
+  category_column: "lulc"
+  colors:
+    "1": "#419bdf"    # Water
+    "2": "#397d49"    # Trees
+  labels:
+    "1": "Water"
+    "2": "Trees"

--- a/configs/olmoearth_v1_2_tiny_s1s2.yaml
+++ b/configs/olmoearth_v1_2_tiny_s1s2.yaml
@@ -1,0 +1,120 @@
+experiment_name: "OlmoEarth V1.2 Tiny - S2+S1"
+data_version: "v0.50.1"
+chip_tracker: "gelos_chip_tracker.geojson"
+chip_id_column: "id"
+
+seed_everything: 0
+trainer:
+  accelerator: auto
+  strategy: auto
+  devices: auto
+  num_nodes: 1
+  callbacks: []
+  max_epochs: 0
+
+data:
+  class_path: gelos.gelosdatamodule.GELOSDataModule
+  init_args:
+    dataset_class: gelos.gelosdataset.GELOSDataSet
+    batch_size: 8
+    num_workers: 4
+    # OlmoEarth S2+S1 mode. S2 requires the full 12-band S2L2A set (including
+    # WATER_VAPOR / B09) as RAW digital numbers (0-10000). S1 requires VV and VH
+    # as RAW LINEAR POWER gamma0 (e.g. Planetary Computer sentinel-1-rtc) -- the
+    # backbone converts S1 to dB and applies OlmoEarth's pretraining
+    # normalization to both modalities internally, hence normalize: false below.
+    # Do NOT set db_scale_bands for S1 here, or values get double-transformed.
+    normalize: false
+    bands:
+      S2L2A:
+        - COASTAL_AEROSOL   # B01
+        - BLUE              # B02
+        - GREEN             # B03
+        - RED               # B04
+        - RED_EDGE_1        # B05
+        - RED_EDGE_2        # B06
+        - RED_EDGE_3        # B07
+        - NIR_BROAD         # B08
+        - NIR_NARROW        # B8A
+        - WATER_VAPOR       # B09
+        - SWIR_1            # B11
+        - SWIR_2            # B12
+      S1RTC:
+        - VV
+        - VH
+    transform:
+      - class_path: terratorch.datasets.transforms.FlattenTemporalIntoChannels
+      - class_path: albumentations.augmentations.geometric.resize.Resize
+        init_args:
+          height: 96
+          width: 96
+          interpolation: 0 # Nearest Neighbor
+      - class_path: albumentations.pytorch.transforms.ToTensorV2
+      - class_path: terratorch.datasets.transforms.UnflattenTemporalFromChannels
+        init_args:
+          n_timesteps: 4
+model:
+  class_path: terratorch.tasks.EmbeddingGenerationTask
+  title: OlmoEarth V1.2 Tiny S2+S1
+  init_args:
+    model: olmoearth_v1_2_tiny_s1s2  # registered via gelos.backbones.olmoearth_backbone
+    model_args:
+      model_id: allenai/OlmoEarth-v1_2-Tiny
+      pretrained: True
+      patch_size: 4
+      # Bands in the order the incoming tensor presents them; the wrapper reorders
+      # to OlmoEarth's internal 12-band order. Must match data.bands.S2L2A above.
+      bands:
+        - COASTAL_AEROSOL
+        - BLUE
+        - GREEN
+        - RED
+        - RED_EDGE_1
+        - RED_EDGE_2
+        - RED_EDGE_3
+        - NIR_BROAD
+        - NIR_NARROW
+        - WATER_VAPOR
+        - SWIR_1
+        - SWIR_2
+      # S1 bands in the order the incoming tensor presents them. Must match
+      # data.bands.S1RTC above. S1 input must be RAW linear power; the wrapper
+      # converts to dB and normalizes internally (apply_pretraining_normalization).
+      bands_s1:
+        - VV
+        - VH
+    output_format: parquet
+    embed_file_key: filename
+    layers: [-1] # Model layers to extract embeddings from, -1 means the last layer
+    embedding_pooling: null
+    has_cls: False
+    temporal_cfg:
+      # temporal_wrapper MUST be False for OlmoEarth. TemporalWrapper.forward
+      # reshapes (B,C,T,H,W) -> (B*T,C,H,W) (4D) before calling the backbone, but
+      # OlmoEarthBackbone.forward_features requires a 5D (B,C,T,H,W) tensor and
+      # raises on 4D input. OlmoEarth runs on the un-wrapped 5D path, where the
+      # per-timestep (B,T,3) timestamps also align with the temporal axis.
+      temporal_wrapper: False
+      temporal_pooling: keep
+
+# each strategy defines extraction args (slice_args) and optional analysis steps
+embedding_extraction_strategies:
+  all_embeddings:
+    title: "All Embeddings"
+    slice_args:
+      - start: 0
+        stop: null
+        step:
+    transforms:
+      - type: pca
+        params:
+          n_components: 2
+
+style:
+  category_column: "lulc"
+  colors:
+    "1": "#419bdf"    # Water
+    "2": "#397d49"    # Trees
+  labels:
+    "1": "Water"
+    "2": "Trees"

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -169,7 +169,7 @@ with `COASTAL_AEROSOL`) raises an error; override with explicit `means`/`stds` i
 
 | Field | Purpose |
 |-------|---------|
-| `model` | TerraTorch model identifier (e.g., `prithvi_eo_v2_300`, `prithvi_eo_v2_600`, `terramind_v1_base`, `olmoearth_v1_base`, `olmoearth_v1_base_s1s2`) |
+| `model` | TerraTorch model identifier (e.g., `prithvi_eo_v2_300`, `prithvi_eo_v2_600`, `terramind_v1_base`, `olmoearth_v1_base`, `olmoearth_v1_base_s1s2`, `olmoearth_v1_2_base`) |
 | `model_args.bands` | Band names as the **model** expects them (may differ from your dataset band names) |
 | `model_args.bands_s1` | S1 band names for OlmoEarth S1+S2 models (e.g., `[VV, VH]`). Omit or set to null to disable S1. |
 | `layers` | Which transformer layers to extract embeddings from. `-1` means the last layer |
@@ -182,9 +182,11 @@ Ai2's [OlmoEarth](https://pypi.org/project/olmoearth-pretrain/) is supported as 
 terratorch-compatible backbone via a wrapper in `gelos/backbones/olmoearth_backbone.py`,
 which registers itself automatically when `gelos.generation` is imported. No file
 placement is required — install the extra and use the model identifiers directly.
-Four model sizes are available:
-`nano` (D=128), `tiny` (D=192), `base` (D=768), and `large` (D=1024). Each size
-has a Sentinel-2-only variant and a combined S2+S1 variant:
+Two generations are available: **v1** with sizes
+`nano` (D=128), `tiny` (D=192), `base` (D=768), and `large` (D=1024); and **v1.2**
+with sizes `nano` (D=128), `tiny` (D=192), `small` (D=384), and `base` (D=768).
+Note v1.2 adds a `small` size and drops `large`. Each size has a Sentinel-2-only
+variant and a combined S2+S1 variant:
 
 | Model identifier | Sensors | Hidden dim |
 |---|---|---|
@@ -196,6 +198,20 @@ has a Sentinel-2-only variant and a combined S2+S1 variant:
 | `olmoearth_v1_tiny_s1s2` | S2 + S1 | 192 |
 | `olmoearth_v1_base_s1s2` | S2 + S1 | 768 |
 | `olmoearth_v1_large_s1s2` | S2 + S1 | 1024 |
+
+OlmoEarth v1.2 improves embedding quality over v1 and reuses v1's band order and
+pretraining normalization statistics unchanged:
+
+| Model identifier | Sensors | Hidden dim |
+|---|---|---|
+| `olmoearth_v1_2_nano` | S2 only | 128 |
+| `olmoearth_v1_2_tiny` | S2 only | 192 |
+| `olmoearth_v1_2_small` | S2 only | 384 |
+| `olmoearth_v1_2_base` | S2 only | 768 |
+| `olmoearth_v1_2_nano_s1s2` | S2 + S1 | 128 |
+| `olmoearth_v1_2_tiny_s1s2` | S2 + S1 | 192 |
+| `olmoearth_v1_2_small_s1s2` | S2 + S1 | 384 |
+| `olmoearth_v1_2_base_s1s2` | S2 + S1 | 768 |
 
 Notes and limitations:
 

--- a/gelos/backbones/olmoearth_backbone.py
+++ b/gelos/backbones/olmoearth_backbone.py
@@ -836,6 +836,270 @@ def olmoearth_v1_large_s1s2(
     )
 
 
+def olmoearth_v1_2_nano(
+    pretrained: bool = True,
+    model_id: str = "allenai/OlmoEarth-v1_2-Nano",
+    bands: list[str] | None = None,
+    patch_size: int = 4,
+    apply_pretraining_normalization: bool = True,
+    hidden_dim: int | None = 128,
+    **kwargs,
+) -> OlmoEarthBackbone:
+    """Terratorch backbone factory for the OlmoEarth v1.2 Nano checkpoint (D=128).
+
+    Registered under its own name (``olmoearth_v1_2_nano``) in
+    ``gelos.backbones.olmoearth_backbone``; ``BACKBONE_REGISTRY.build("olmoearth_v1_2_nano",
+    **model_args)`` returns an :class:`OlmoEarthBackbone`.
+
+    NOTE: inputs must be RAW S2 L2A digital numbers (0-10000). With
+    ``apply_pretraining_normalization=True`` (default) the wrapper min-max
+    normalizes each band over mean±2σ, exactly as OlmoEarth's pretraining data
+    loader did. Configure the datamodule with ``normalize: false``.
+    """
+    return OlmoEarthBackbone(
+        pretrained=pretrained,
+        model_id=model_id,
+        bands=bands,
+        patch_size=patch_size,
+        apply_pretraining_normalization=apply_pretraining_normalization,
+        hidden_dim=hidden_dim,
+        **kwargs,
+    )
+
+
+def olmoearth_v1_2_tiny(
+    pretrained: bool = True,
+    model_id: str = "allenai/OlmoEarth-v1_2-Tiny",
+    bands: list[str] | None = None,
+    patch_size: int = 4,
+    apply_pretraining_normalization: bool = True,
+    hidden_dim: int | None = 192,
+    **kwargs,
+) -> OlmoEarthBackbone:
+    """Terratorch backbone factory for the OlmoEarth v1.2 Tiny checkpoint (D=192).
+
+    Registered under its own name (``olmoearth_v1_2_tiny``) in
+    ``gelos.backbones.olmoearth_backbone``; ``BACKBONE_REGISTRY.build("olmoearth_v1_2_tiny",
+    **model_args)`` returns an :class:`OlmoEarthBackbone`.
+
+    NOTE: inputs must be RAW S2 L2A digital numbers (0-10000). With
+    ``apply_pretraining_normalization=True`` (default) the wrapper min-max
+    normalizes each band over mean±2σ, exactly as OlmoEarth's pretraining data
+    loader did. Configure the datamodule with ``normalize: false``.
+    """
+    return OlmoEarthBackbone(
+        pretrained=pretrained,
+        model_id=model_id,
+        bands=bands,
+        patch_size=patch_size,
+        apply_pretraining_normalization=apply_pretraining_normalization,
+        hidden_dim=hidden_dim,
+        **kwargs,
+    )
+
+
+def olmoearth_v1_2_small(
+    pretrained: bool = True,
+    model_id: str = "allenai/OlmoEarth-v1_2-Small",
+    bands: list[str] | None = None,
+    patch_size: int = 4,
+    apply_pretraining_normalization: bool = True,
+    hidden_dim: int | None = 384,
+    **kwargs,
+) -> OlmoEarthBackbone:
+    """Terratorch backbone factory for the OlmoEarth v1.2 Small checkpoint (D=384).
+
+    Registered under its own name (``olmoearth_v1_2_small``) in
+    ``gelos.backbones.olmoearth_backbone``; ``BACKBONE_REGISTRY.build("olmoearth_v1_2_small",
+    **model_args)`` returns an :class:`OlmoEarthBackbone`.
+
+    NOTE: inputs must be RAW S2 L2A digital numbers (0-10000). With
+    ``apply_pretraining_normalization=True`` (default) the wrapper min-max
+    normalizes each band over mean±2σ, exactly as OlmoEarth's pretraining data
+    loader did. Configure the datamodule with ``normalize: false``.
+    """
+    return OlmoEarthBackbone(
+        pretrained=pretrained,
+        model_id=model_id,
+        bands=bands,
+        patch_size=patch_size,
+        apply_pretraining_normalization=apply_pretraining_normalization,
+        hidden_dim=hidden_dim,
+        **kwargs,
+    )
+
+
+def olmoearth_v1_2_base(
+    pretrained: bool = True,
+    model_id: str = "allenai/OlmoEarth-v1_2-Base",
+    bands: list[str] | None = None,
+    patch_size: int = 4,
+    apply_pretraining_normalization: bool = True,
+    hidden_dim: int | None = 768,
+    **kwargs,
+) -> OlmoEarthBackbone:
+    """Terratorch backbone factory for the OlmoEarth v1.2 Base checkpoint (D=768).
+
+    Registered under its own name (``olmoearth_v1_2_base``) in
+    ``gelos.backbones.olmoearth_backbone``; ``BACKBONE_REGISTRY.build("olmoearth_v1_2_base",
+    **model_args)`` returns an :class:`OlmoEarthBackbone`.
+
+    NOTE: inputs must be RAW S2 L2A digital numbers (0-10000). With
+    ``apply_pretraining_normalization=True`` (default) the wrapper min-max
+    normalizes each band over mean±2σ, exactly as OlmoEarth's pretraining data
+    loader did. Configure the datamodule with ``normalize: false``.
+    """
+    return OlmoEarthBackbone(
+        pretrained=pretrained,
+        model_id=model_id,
+        bands=bands,
+        patch_size=patch_size,
+        apply_pretraining_normalization=apply_pretraining_normalization,
+        hidden_dim=hidden_dim,
+        **kwargs,
+    )
+
+
+def olmoearth_v1_2_nano_s1s2(
+    pretrained: bool = True,
+    model_id: str = "allenai/OlmoEarth-v1_2-Nano",
+    bands: list[str] | None = None,
+    bands_s1: list[str] | None = None,
+    patch_size: int = 4,
+    apply_pretraining_normalization: bool = True,
+    hidden_dim: int | None = 128,
+    **kwargs,
+) -> OlmoEarthBackbone:
+    """Terratorch backbone factory for OlmoEarth v1.2 Nano with S2+S1 combined input (D=128).
+
+    Pass ``bands_s1=["VV", "VH"]`` (or via YAML ``model_args.bands_s1``) to enable S1.
+    Omitting ``bands_s1`` falls back to S2-only, identical to ``olmoearth_v1_2_nano``.
+
+    NOTE: inputs must be RAW sensor scale — S2 L2A digital numbers (0-10000) and
+    S1 linear-power gamma0 (e.g. Planetary Computer sentinel-1-rtc). With
+    ``apply_pretraining_normalization=True`` (default) the wrapper converts S1 to
+    dB and min-max normalizes both modalities per band over mean±2σ, exactly as
+    OlmoEarth's pretraining data loader did. Configure the datamodule with
+    ``normalize: false`` and do NOT apply ``db_scale_bands`` to S1, or values get
+    double-transformed.
+    """
+    return OlmoEarthBackbone(
+        pretrained=pretrained,
+        model_id=model_id,
+        bands=bands,
+        bands_s1=bands_s1,
+        patch_size=patch_size,
+        apply_pretraining_normalization=apply_pretraining_normalization,
+        hidden_dim=hidden_dim,
+        **kwargs,
+    )
+
+
+def olmoearth_v1_2_tiny_s1s2(
+    pretrained: bool = True,
+    model_id: str = "allenai/OlmoEarth-v1_2-Tiny",
+    bands: list[str] | None = None,
+    bands_s1: list[str] | None = None,
+    patch_size: int = 4,
+    apply_pretraining_normalization: bool = True,
+    hidden_dim: int | None = 192,
+    **kwargs,
+) -> OlmoEarthBackbone:
+    """Terratorch backbone factory for OlmoEarth v1.2 Tiny with S2+S1 combined input (D=192).
+
+    Pass ``bands_s1=["VV", "VH"]`` (or via YAML ``model_args.bands_s1``) to enable S1.
+    Omitting ``bands_s1`` falls back to S2-only, identical to ``olmoearth_v1_2_tiny``.
+
+    NOTE: inputs must be RAW sensor scale — S2 L2A digital numbers (0-10000) and
+    S1 linear-power gamma0 (e.g. Planetary Computer sentinel-1-rtc). With
+    ``apply_pretraining_normalization=True`` (default) the wrapper converts S1 to
+    dB and min-max normalizes both modalities per band over mean±2σ, exactly as
+    OlmoEarth's pretraining data loader did. Configure the datamodule with
+    ``normalize: false`` and do NOT apply ``db_scale_bands`` to S1, or values get
+    double-transformed.
+    """
+    return OlmoEarthBackbone(
+        pretrained=pretrained,
+        model_id=model_id,
+        bands=bands,
+        bands_s1=bands_s1,
+        patch_size=patch_size,
+        apply_pretraining_normalization=apply_pretraining_normalization,
+        hidden_dim=hidden_dim,
+        **kwargs,
+    )
+
+
+def olmoearth_v1_2_small_s1s2(
+    pretrained: bool = True,
+    model_id: str = "allenai/OlmoEarth-v1_2-Small",
+    bands: list[str] | None = None,
+    bands_s1: list[str] | None = None,
+    patch_size: int = 4,
+    apply_pretraining_normalization: bool = True,
+    hidden_dim: int | None = 384,
+    **kwargs,
+) -> OlmoEarthBackbone:
+    """Terratorch backbone factory for OlmoEarth v1.2 Small with S2+S1 combined input (D=384).
+
+    Pass ``bands_s1=["VV", "VH"]`` (or via YAML ``model_args.bands_s1``) to enable S1.
+    Omitting ``bands_s1`` falls back to S2-only, identical to ``olmoearth_v1_2_small``.
+
+    NOTE: inputs must be RAW sensor scale — S2 L2A digital numbers (0-10000) and
+    S1 linear-power gamma0 (e.g. Planetary Computer sentinel-1-rtc). With
+    ``apply_pretraining_normalization=True`` (default) the wrapper converts S1 to
+    dB and min-max normalizes both modalities per band over mean±2σ, exactly as
+    OlmoEarth's pretraining data loader did. Configure the datamodule with
+    ``normalize: false`` and do NOT apply ``db_scale_bands`` to S1, or values get
+    double-transformed.
+    """
+    return OlmoEarthBackbone(
+        pretrained=pretrained,
+        model_id=model_id,
+        bands=bands,
+        bands_s1=bands_s1,
+        patch_size=patch_size,
+        apply_pretraining_normalization=apply_pretraining_normalization,
+        hidden_dim=hidden_dim,
+        **kwargs,
+    )
+
+
+def olmoearth_v1_2_base_s1s2(
+    pretrained: bool = True,
+    model_id: str = "allenai/OlmoEarth-v1_2-Base",
+    bands: list[str] | None = None,
+    bands_s1: list[str] | None = None,
+    patch_size: int = 4,
+    apply_pretraining_normalization: bool = True,
+    hidden_dim: int | None = 768,
+    **kwargs,
+) -> OlmoEarthBackbone:
+    """Terratorch backbone factory for OlmoEarth v1.2 Base with S2+S1 combined input (D=768).
+
+    Pass ``bands_s1=["VV", "VH"]`` (or via YAML ``model_args.bands_s1``) to enable S1.
+    Omitting ``bands_s1`` falls back to S2-only, identical to ``olmoearth_v1_2_base``.
+
+    NOTE: inputs must be RAW sensor scale — S2 L2A digital numbers (0-10000) and
+    S1 linear-power gamma0 (e.g. Planetary Computer sentinel-1-rtc). With
+    ``apply_pretraining_normalization=True`` (default) the wrapper converts S1 to
+    dB and min-max normalizes both modalities per band over mean±2σ, exactly as
+    OlmoEarth's pretraining data loader did. Configure the datamodule with
+    ``normalize: false`` and do NOT apply ``db_scale_bands`` to S1, or values get
+    double-transformed.
+    """
+    return OlmoEarthBackbone(
+        pretrained=pretrained,
+        model_id=model_id,
+        bands=bands,
+        bands_s1=bands_s1,
+        patch_size=patch_size,
+        apply_pretraining_normalization=apply_pretraining_normalization,
+        hidden_dim=hidden_dim,
+        **kwargs,
+    )
+
+
 import logging as _logging
 
 _logger = _logging.getLogger("terratorch")
@@ -851,13 +1115,25 @@ try:
         olmoearth_v1_tiny_s1s2,
         olmoearth_v1_base_s1s2,
         olmoearth_v1_large_s1s2,
+        olmoearth_v1_2_nano,
+        olmoearth_v1_2_tiny,
+        olmoearth_v1_2_small,
+        olmoearth_v1_2_base,
+        olmoearth_v1_2_nano_s1s2,
+        olmoearth_v1_2_tiny_s1s2,
+        olmoearth_v1_2_small_s1s2,
+        olmoearth_v1_2_base_s1s2,
     ):
         _REG.register(_f)
     _logger.info(
         "Registered OlmoEarth backbones: 'olmoearth_v1_nano', "
         "'olmoearth_v1_tiny', 'olmoearth_v1_base', 'olmoearth_v1_large', "
         "'olmoearth_v1_nano_s1s2', 'olmoearth_v1_tiny_s1s2', "
-        "'olmoearth_v1_base_s1s2', 'olmoearth_v1_large_s1s2'."
+        "'olmoearth_v1_base_s1s2', 'olmoearth_v1_large_s1s2', "
+        "'olmoearth_v1_2_nano', 'olmoearth_v1_2_tiny', "
+        "'olmoearth_v1_2_small', 'olmoearth_v1_2_base', "
+        "'olmoearth_v1_2_nano_s1s2', 'olmoearth_v1_2_tiny_s1s2', "
+        "'olmoearth_v1_2_small_s1s2', 'olmoearth_v1_2_base_s1s2'."
     )
 except Exception as _exc:
     import traceback as _tb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "loguru",
     "umap-learn>=0.5,<0.6",
     "zarr>=3.0",
-    "olmoearth-pretrain>=0.1.0",
+    "olmoearth-pretrain>=0.1.1",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_olmoearth_backbone.py
+++ b/tests/test_olmoearth_backbone.py
@@ -521,3 +521,47 @@ def test_example_s1s2_fixture_yaml_valid():
     model_args = config["model"]["init_args"]["model_args"]
     assert "bands_s1" in model_args
     assert set(model_args["bands_s1"]) == {"VV", "VH"}
+
+
+# ---------------------------------------------------------------------------
+# OlmoEarth v1.2 factory tests (model-free: signature + registry only).
+# ---------------------------------------------------------------------------
+
+# (factory name, hidden_dim default, model_id default) for all 8 v1.2 factories.
+V1_2_FACTORIES = [
+    ("olmoearth_v1_2_nano", 128, "allenai/OlmoEarth-v1_2-Nano"),
+    ("olmoearth_v1_2_tiny", 192, "allenai/OlmoEarth-v1_2-Tiny"),
+    ("olmoearth_v1_2_small", 384, "allenai/OlmoEarth-v1_2-Small"),
+    ("olmoearth_v1_2_base", 768, "allenai/OlmoEarth-v1_2-Base"),
+    ("olmoearth_v1_2_nano_s1s2", 128, "allenai/OlmoEarth-v1_2-Nano"),
+    ("olmoearth_v1_2_tiny_s1s2", 192, "allenai/OlmoEarth-v1_2-Tiny"),
+    ("olmoearth_v1_2_small_s1s2", 384, "allenai/OlmoEarth-v1_2-Small"),
+    ("olmoearth_v1_2_base_s1s2", 768, "allenai/OlmoEarth-v1_2-Base"),
+]
+
+
+@pytest.mark.parametrize("name, hidden_dim, model_id", V1_2_FACTORIES)
+def test_v1_2_factory_defaults(name, hidden_dim, model_id):
+    import inspect
+
+    import gelos.backbones.olmoearth_backbone as oe
+
+    fn = getattr(oe, name)
+    params = inspect.signature(fn).parameters
+    assert params["hidden_dim"].default == hidden_dim
+    assert params["model_id"].default == model_id
+    # The _s1s2 variants must expose the extra bands_s1 pass-through param.
+    if name.endswith("_s1s2"):
+        assert "bands_s1" in params
+
+
+def test_v1_2_factories_registered():
+    try:
+        from terratorch.registry import TERRATORCH_BACKBONE_REGISTRY
+    except ImportError:
+        pytest.skip("terratorch registry not importable in this environment")
+    # Importing the module triggers self-registration of the factories.
+    import gelos.backbones.olmoearth_backbone  # noqa: F401
+
+    for name, _hidden_dim, _model_id in V1_2_FACTORIES:
+        assert name in TERRATORCH_BACKBONE_REGISTRY


### PR DESCRIPTION
This PR adds OlmoEarth v1.2 to GELOS by registering new backbones in the exiting olmoearth backbone. It requires an update to the newest version of the olmoearth package as well, so any containers running the previous installation of GELOS will need to be updated to reflect this change.